### PR TITLE
feature(ORM): add new APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,5 @@
 # Simple python SQLite3 ORM
 
-## Usage
+## Sample usage
 
-```python
-class SomeTable(ORMBase):
-    prim_key_mystr: Annotated[
-        MyStr,
-        TypeAffinityRepr(MyStr),
-        ConstrainRepr("PRIMARY KEY"),
-    ]
-    optional_str_enum: Annotated[
-        Optional[SomeStrEnum],
-        TypeAffinityRepr(SomeStrEnum),
-    ] = None
-    some_i_enum: Annotated[
-        SomeIntEnum,
-        TypeAffinityRepr(SomeIntEnum),
-        ConstrainRepr("NOT NULL", ("CHECK", "(some_i_enum > 0 AND some_i_enum < 4)")),
-    ]
-    bytes: Annotated[
-        bytes,
-        TypeAffinityRepr(bytes),
-        ConstrainRepr("NOT NULL"),
-    ]
-    unique_myfloat: Annotated[
-        MyFloat,
-        TypeAffinityRepr(MyFloat),
-        ConstrainRepr("UNIQUE"),
-    ]
-    optional_str_literal: Annotated[
-        Optional[SomeStrLiteral],
-        TypeAffinityRepr(SomeStrLiteral),
-    ] = None
-    default_i_literal: Annotated[
-        SomeIntLiteral,
-        TypeAffinityRepr(SomeIntLiteral),
-        ConstrainRepr(
-            "NOT NULL",
-            ("CHECK", "(default_i_literal > 0 AND default_i_literal < 4)"),
-            ("DEFAULT", "2"),
-        ),
-    ] = 2
-```
+Check [sample_db.table](tests/sample_db/table.py) for more details.

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -444,15 +444,6 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
             thread_name_prefix=thread_name_prefix,
         )
 
-    def shutdown(self) -> None:
-        """Close all the connections used by this pool."""
-        with self._shutdown_lock:
-            if self._closed:
-                return
-            self._closed = True
-            for con in self._thread_id_cons.values():
-                con.close()
-
     @property
     @deprecated("orm_con is not available in thread pool ORM")
     def orm_con(self):

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -459,10 +459,17 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         """Not implemented, orm_con is not available in thread pool ORM."""
         raise NotImplementedError("orm_con is not available in thread pool ORM")
 
-    def orm_pool_shutdown(self, *, wait=True):
+    def orm_pool_shutdown(self, *, wait=True, close_connections=True) -> None:
+        """Shutdown the ORM connections thread pool.
+
+        Args:
+            wait (bool, optional): Wait for threads join. Defaults to True.
+            close_connections (bool, optional): Close all the connections. Defaults to True.
+        """
         self._pool.shutdown(wait=wait)
-        for con in self._thread_id_cons.values():
-            con.close()
+        if close_connections:
+            for con in self._thread_id_cons.values():
+                con.close()
         self._thread_id_cons = {}
 
     @copy_callable_typehint(ORMBase.orm_create_table)

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -464,6 +464,13 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
                 con.close()
         self._thread_id_cons = {}
 
+    def orm_execute(
+        self, sql_stmt: str, params: tuple[Any, ...] | dict[str, Any] | None = None
+    ) -> list[Any]:
+        return self._pool.submit(super().orm_execute, sql_stmt, params).result()
+
+    orm_execute.__doc__ = ORMBase.orm_execute.__doc__
+
     @copy_callable_typehint(ORMBase.orm_create_table)
     def orm_create_table(self, *args, **kwargs):
         self._pool.submit(super().orm_create_table, *args, **kwargs).result()

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -639,6 +639,21 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
 
         return await self._run_in_pool(_inner)
 
+    async def orm_select_entry(
+        self,
+        *,
+        _distinct: bool = False,
+        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
+        **col_values: Any,
+    ) -> TableSpecType | None:
+        return await self._run_in_pool(
+            ORMBase.orm_select_entry,
+            self,
+            _distinct=_distinct,
+            _order_by=_order_by,
+            **col_values,
+        )
+
     async def orm_delete_entries(
         self,
         *,

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -125,6 +125,32 @@ class ORMBase(Generic[TableSpecType]):
             else self._table_name
         )
 
+    def orm_execute(
+        self, sql_stmt: str, params: tuple[Any, ...] | dict[str, Any] | None = None
+    ) -> list[Any]:
+        """Execute one sql statement and get the all the result.
+
+        The result will be fetched with fetchall API and returned as it.
+
+        This method is inteneded for executing simple sql_stmt with small result.
+        For complicated sql statement and large result, please use sqlite3.Connection object
+            exposed by orm_con and manipulate the Cursor object by yourselves.
+
+        Args:
+            sql_stmt (str): The sqlite statement to be executed.
+            params (tuple[Any, ...] | dict[str, Any] | None, optional): The parameters to be bound
+                to the sql statement execution. Defaults to None, not passing any params.
+
+        Returns:
+            list[Any]: A list contains all the result entries.
+        """
+        with self._con as con:
+            if params:
+                cur = con.execute(sql_stmt, params)
+            else:
+                cur = con.execute(sql_stmt)
+            return cur.fetchall()
+
     def orm_create_table(
         self,
         *,

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -612,6 +612,11 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         """Not implemented, orm_con is not available in thread pool ORM."""
         raise NotImplementedError("orm_con is not available in thread pool ORM")
 
+    async def orm_execute(
+        self, sql_stmt: str, params: tuple[Any, ...] | dict[str, Any] | None = None
+    ) -> list[Any]:
+        return await self._run_in_pool(ORMBase.orm_execute, self, sql_stmt, params)
+
     def orm_select_entries_gen(
         self,
         *,

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -229,6 +229,9 @@ class ORMBase(Generic[TableSpecType]):
     ) -> TableSpecType | None:
         """Select exactly one entry from the table accordingly.
 
+        NOTE that if the select result contains more than one entry, this method will return
+            the FIRST one from the result with fetchone API.
+
         Args:
             _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
             _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
@@ -244,7 +247,6 @@ class ORMBase(Generic[TableSpecType]):
             select_from=self.orm_table_name,
             distinct=_distinct,
             order_by=_order_by,
-            limit=1,
             where_cols=tuple(col_values),
         )
 

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -609,6 +609,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
     ) -> list[Any]:
         return await self._run_in_pool(ORMBase.orm_execute, self, sql_stmt, params)
 
+    orm_execute.__doc__ = ORMBase.orm_execute.__doc__
+
     def orm_select_entries_gen(
         self,
         *,
@@ -686,6 +688,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
             **col_values,
         )
 
+    orm_select_entry.__doc__ = ORMBase.orm_select_entry
+
     async def orm_delete_entries(
         self,
         *,
@@ -710,6 +714,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
 
         return await self._run_in_pool(_inner)
 
+    orm_delete_entries.__doc__ = ORMBase.orm_delete_entries.__doc__
+
     async def orm_create_table(
         self,
         *,
@@ -722,6 +728,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
             allow_existed=allow_existed,
             without_rowid=without_rowid,
         )
+
+    orm_create_table.__doc__ = ORMBase.orm_create_table.__doc__
 
     async def orm_create_index(
         self,
@@ -740,6 +748,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
             unique=unique,
         )
 
+    orm_create_index.__doc__ = ORMBase.orm_create_index.__doc__
+
     async def orm_insert_entries(
         self, _in: Iterable[TableSpecType], *, or_option: INSERT_OR | None = None
     ) -> int:
@@ -747,9 +757,13 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
             ORMBase.orm_insert_entries, self, _in, or_option=or_option
         )
 
+    orm_insert_entries.__doc__ = ORMBase.orm_insert_entries.__doc__
+
     async def orm_insert_entry(
         self, _in: TableSpecType, *, or_option: INSERT_OR | None = None
     ) -> int:
         return await self._run_in_pool(
             ORMBase.orm_insert_entry, self, _in, or_option=or_option
         )
+
+    orm_insert_entry.__doc__ = ORMBase.orm_insert_entry.__doc__

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -425,9 +425,6 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         number_of_cons: int,
         thread_name_prefix: str = "",
     ) -> None:
-        self._closed = False
-        self._shutdown_lock = threading.Lock()
-
         self._table_name = table_name
         self._schema_name = schema_name
 
@@ -452,6 +449,10 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
 
     def orm_pool_shutdown(self, *, wait=True, close_connections=True) -> None:
         """Shutdown the ORM connections thread pool.
+
+        It is safe to call this method multiple time.
+        This method is NOT thread-safe, and should be called at the main thread,
+            or the thread that creates this thread pool.
 
         Args:
             wait (bool, optional): Wait for threads join. Defaults to True.

--- a/src/simple_sqlite3_orm/_orm.py
+++ b/src/simple_sqlite3_orm/_orm.py
@@ -480,6 +480,7 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         _limit: int | None = None,
         **col_values: Any,
     ) -> Generator[TableSpecType, None, None]:
+        """Select multiple entries and return a generator for yielding entries from."""
         _queue = queue.SimpleQueue()
 
         def _inner():
@@ -521,6 +522,8 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         _limit: int | None = None,
         **col_values: Any,
     ) -> list[TableSpecType]:
+        """Select multiple entries and return all the entries in a list."""
+
         def _inner():
             return list(
                 ORMBase.orm_select_entries(
@@ -619,6 +622,7 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         _limit: int | None = None,
         **col_values: Any,
     ) -> AsyncGenerator[TableSpecType, Any]:
+        """Select multiple entries and return an async generator for yielding entries from."""
         _async_queue = asyncio.Queue()
 
         def _inner():
@@ -660,6 +664,8 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         _limit: int | None = None,
         **col_values: Any,
     ) -> list[TableSpecType]:
+        """Select multiple entries and return all the entries in a list."""
+
         def _inner():
             return list(
                 ORMBase.orm_select_entries(

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -7,7 +7,7 @@ from typing_extensions import ParamSpec
 P = ParamSpec("P")
 
 
-def copy_callable_typehint(_: Callable[P, Any]):
+def copy_callable_typehint(src: Callable[P, Any]):
     """This helper function return a decorator that can type hint the target
     function as the _source function.
 
@@ -17,6 +17,7 @@ def copy_callable_typehint(_: Callable[P, Any]):
     """
 
     def _decorator(target) -> Callable[P, Any]:
+        target.__doc__ = src.__doc__
         return target
 
     return _decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def setup_test_data():
 def setup_test_db(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Generator[SampleDB, None, None]:
-    """Setup a single db connection."""
+    """Setup a single db connection for a test class."""
     tmp_path = tmp_path_factory.mktemp("tmp_db_path")
     db_file = tmp_path / "test_db_file.sqlite3"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,30 @@ def generate_test_data(num_of_entry: int) -> dict[str, SampleTable]:
     return res
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def setup_test_data():
     return generate_test_data(TEST_ENTRY_NUM)
+
+
+@pytest.fixture(scope="session")
+def entries_to_lookup(setup_test_data: dict[str, SampleTable]) -> list[SampleTable]:
+    return random.sample(
+        list(setup_test_data.values()),
+        k=TEST_LOOKUP_ENTRIES_NUM,
+    )
+
+
+@pytest.fixture(scope="session")
+def entries_to_remove(setup_test_data: dict[str, SampleTable]) -> list[SampleTable]:
+    return random.sample(
+        list(setup_test_data.values()),
+        k=TEST_REMOVE_ENTRIES_NUM,
+    )
+
+
+@pytest.fixture(scope="session")
+def entry_to_lookup(setup_test_data: dict[str, SampleTable]) -> SampleTable:
+    return random.choice(list(setup_test_data.values()))
 
 
 @pytest.fixture(scope="class")
@@ -119,19 +140,3 @@ def setup_con_factory(
         return con
 
     return con_factory
-
-
-@pytest.fixture(scope="class")
-def entries_to_lookup(setup_test_data: dict[str, SampleTable]) -> list[SampleTable]:
-    return random.sample(
-        list(setup_test_data.values()),
-        k=TEST_LOOKUP_ENTRIES_NUM,
-    )
-
-
-@pytest.fixture(scope="class")
-def entries_to_remove(setup_test_data: dict[str, SampleTable]) -> list[SampleTable]:
-    return random.sample(
-        list(setup_test_data.values()),
-        k=TEST_REMOVE_ENTRIES_NUM,
-    )

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -93,6 +93,19 @@ class TestORMBase:
         setup_connection.orm_insert_entry(entry_for_test, or_option="ignore")
         setup_connection.orm_insert_entry(entry_for_test, or_option="replace")
 
+    def test_orm_execute(self, setup_connection: ORMTest):
+        sql_stmt = setup_connection.orm_table_spec.table_select_stmt(
+            select_from=setup_connection.orm_table_name,
+            select_cols="*",
+            function="count",
+        )
+
+        res = setup_connection.orm_execute(sql_stmt)
+        assert res and res[0][0] > 0
+
+    def test_select_entry(self, setup_connection: ORMTest):
+        assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)
+
     def test_select_entries(self, setup_connection: ORMTest):
         select_result = setup_connection.orm_select_entries(
             _distinct=True,

--- a/tests/test_e2e/test_asyncio.py
+++ b/tests/test_e2e/test_asyncio.py
@@ -6,7 +6,6 @@ import sqlite3
 import time
 from typing import Callable
 
-import pytest
 import pytest_asyncio
 
 from simple_sqlite3_orm._orm import AsyncORMThreadPoolBase
@@ -26,11 +25,9 @@ class SampleDBAsyncio(AsyncORMThreadPoolBase[SampleTable]):
     """Test connection pool with async API."""
 
 
-@pytest.mark.asyncio(scope="class")
 class TestWithSampleDBWithAsyncIO:
 
     @pytest_asyncio.fixture(scope="class")
-    @pytest.mark.asyncio(scope="class")
     async def async_pool(
         self,
         setup_con_factory: Callable[[], sqlite3.Connection],
@@ -46,7 +43,6 @@ class TestWithSampleDBWithAsyncIO:
             pool.orm_pool_shutdown()
 
     @pytest_asyncio.fixture(autouse=True, scope="class")
-    @pytest.mark.asyncio(scope="class")
     async def start_timer(self) -> tuple[asyncio.Task[None], asyncio.Event]:
         _test_finished = asyncio.Event()
 

--- a/tests/test_e2e/test_asyncio.py
+++ b/tests/test_e2e/test_asyncio.py
@@ -6,6 +6,7 @@ import sqlite3
 import time
 from typing import Callable
 
+import pytest
 import pytest_asyncio
 
 from simple_sqlite3_orm._orm import AsyncORMThreadPoolBase
@@ -25,6 +26,7 @@ class SampleDBAsyncio(AsyncORMThreadPoolBase[SampleTable]):
     """Test connection pool with async API."""
 
 
+@pytest.mark.asyncio(scope="class")
 class TestWithSampleDBWithAsyncIO:
 
     @pytest_asyncio.fixture(scope="class")
@@ -162,5 +164,5 @@ class TestWithSampleDBWithAsyncIO:
         _event.set()
         await _task
 
-    def test_shutdown_pool(self, async_pool: SampleDBAsyncio):
+    async def test_shutdown_pool(self, async_pool: SampleDBAsyncio):
         async_pool.orm_pool_shutdown(wait=True, close_connections=True)

--- a/tests/test_e2e/test_asyncio.py
+++ b/tests/test_e2e/test_asyncio.py
@@ -29,21 +29,6 @@ class SampleDBAsyncio(AsyncORMThreadPoolBase[SampleTable]):
 @pytest.mark.asyncio(scope="class")
 class TestWithSampleDBWithAsyncIO:
 
-    @pytest.fixture(autouse=True)
-    def setup_test(
-        self,
-        setup_test_data: dict[str, SampleTable],
-        entries_to_lookup: list[SampleTable],
-        entries_to_remove: list[SampleTable],
-    ):
-        self.table_name = TABLE_NAME
-
-        self.data_for_test = setup_test_data
-        self.table_spec = SampleTable
-        self.data_len = len(setup_test_data)
-        self.entries_to_lookup = entries_to_lookup
-        self.entries_to_remove = entries_to_remove
-
     @pytest_asyncio.fixture(scope="class")
     @pytest.mark.asyncio(scope="class")
     async def async_pool(
@@ -84,12 +69,14 @@ class TestWithSampleDBWithAsyncIO:
         logger.info("test create table")
         await async_pool.orm_create_table(without_rowid=True)
 
-    async def test_insert_entries_with_pool(self, async_pool: SampleDBAsyncio):
+    async def test_insert_entries_with_pool(
+        self, async_pool: SampleDBAsyncio, setup_test_data: dict[str, SampleTable]
+    ):
         logger.info("test insert entries...")
 
         _tasks = []
         for _batch_count, entry in enumerate(
-            batched(self.data_for_test.values(), TEST_INSERT_BATCH_SIZE),
+            batched(setup_test_data.values(), TEST_INSERT_BATCH_SIZE),
             start=1,
         ):
             _task = asyncio.create_task(async_pool.orm_insert_entries(entry))
@@ -103,10 +90,10 @@ class TestWithSampleDBWithAsyncIO:
         logger.info("confirm data written with orm_select_entries_gen")
         _count = 0
         async for _entry in async_pool.orm_select_entries_gen():
-            _corresponding_item = self.data_for_test[_entry.prim_key]
+            _corresponding_item = setup_test_data[_entry.prim_key]
             assert _corresponding_item == _entry
             _count += 1
-        assert _count == len(self.data_for_test)
+        assert _count == len(setup_test_data)
 
     async def test_create_index(self, async_pool: SampleDBAsyncio):
         logger.info("test create index")
@@ -116,9 +103,11 @@ class TestWithSampleDBWithAsyncIO:
             unique=True,
         )
 
-    async def test_lookup_entries(self, async_pool: SampleDBAsyncio):
+    async def test_lookup_entries(
+        self, async_pool: SampleDBAsyncio, setup_test_data: dict[str, SampleTable]
+    ):
         logger.info("test lookup entries")
-        for _entry in self.entries_to_lookup:
+        for _entry in setup_test_data.values():
             _looked_up = await async_pool.orm_select_entries(
                 key_id=_entry.key_id,
                 prim_key_sha256hash=_entry.prim_key_sha256hash,
@@ -126,7 +115,21 @@ class TestWithSampleDBWithAsyncIO:
             assert len(_looked_up) == 1
             assert _looked_up[0] == _entry
 
-    async def test_delete_entries(self, async_pool: SampleDBAsyncio):
+    async def test_orm_execute(
+        self, async_pool: SampleDBAsyncio, setup_test_data: dict[str, SampleTable]
+    ):
+        logger.info("test orm_execute to check inserted entries num")
+        sql_stmt = async_pool.orm_table_spec.table_select_stmt(
+            select_from=async_pool.orm_table_name,
+            function="count",
+        )
+        res = await async_pool.orm_execute(sql_stmt)
+
+        assert res and res[0][0] == len(setup_test_data)
+
+    async def test_delete_entries(
+        self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
+    ):
         logger.info("test remove and confirm the removed entries")
         if sqlite3.sqlite_version_info < (3, 35, 0):
             logger.warning(
@@ -137,14 +140,14 @@ class TestWithSampleDBWithAsyncIO:
                 )
             )
 
-            for entry in self.entries_to_remove:
+            for entry in entries_to_remove:
                 _res = await async_pool.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
                 )
                 assert _res == 1
         else:
-            for entry in self.entries_to_remove:
+            for entry in entries_to_remove:
                 _res = await async_pool.orm_delete_entries(
                     _returning_cols="*",
                     key_id=entry.key_id,
@@ -162,3 +165,6 @@ class TestWithSampleDBWithAsyncIO:
         _task, _event = start_timer
         _event.set()
         await _task
+
+    def test_shutdown_pool(self, async_pool: SampleDBAsyncio):
+        async_pool.orm_pool_shutdown(wait=True, close_connections=True)


### PR DESCRIPTION
# Introduction
This PR adds new APIs to ORM:

Applies to ORMBase, ORMThreadPoolBase and AsyncORMThreadPoolBase:
1. add orm_execute: similar to sqlite3.Connection.execute, execute one sqlite statement and return all result in a list.
2. add orm_select_entry: select exactly one entry from the database.

Applies to ORMThreadPoolBase and AsyncORMThreadPoolBase:
1. add orm_pool_shutdown: close the threadpool and optionally close the connections used in the pool.

Other changes:
1. add tests covering the new APIs.
2. orm: minor fix to typing.
3. orm: assign API docstrings from ORMBase to each thread pool variants.
4. typing: now copy_callable_typehint will also copy the \_\_doc__ from source to target.
5. minor update and refinement to the test files.