### PR TITLE
fix(table_spec): fix incorrect delete stmt generation with both LIMIT and RETURNING 

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -406,18 +406,18 @@ class TableSpec(BaseModel):
         """
         gen_delete_from_stmt = f"DELETE FROM {delete_from}"
         gen_where_stmt = cls._generate_where_stmt(where_cols, where_stmt)
-        gen_order_by_stmt = cls._generate_order_by_stmt(order_by, order_by_stmt)
-        gen_limit_stmt = f"LIMIT {limit}" if limit is not None else ""
         gen_returning_stmt = cls._generate_returning_stmt(
             returning_cols, returning_stmt
         )
+        gen_order_by_stmt = cls._generate_order_by_stmt(order_by, order_by_stmt)
+        gen_limit_stmt = f"LIMIT {limit}" if limit is not None else ""
 
         res = gen_sql_stmt(
             gen_delete_from_stmt,
             gen_where_stmt,
+            gen_returning_stmt,
             gen_order_by_stmt,
             gen_limit_stmt,
-            gen_returning_stmt,
         )
         logger.debug(res)
         return res

--- a/tests/test_e2e/test_asyncio.py
+++ b/tests/test_e2e/test_asyncio.py
@@ -142,6 +142,7 @@ class TestWithSampleDBWithAsyncIO:
                 _res = await async_pool.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 )
                 assert _res == 1
         else:
@@ -150,6 +151,7 @@ class TestWithSampleDBWithAsyncIO:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 )
                 assert isinstance(_res, list)
 

--- a/tests/test_e2e/test_threadpool.py
+++ b/tests/test_e2e/test_threadpool.py
@@ -125,6 +125,7 @@ class TestWithSampleDBAndThreadPool:
                 _res = thread_pool.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 ).result()
                 assert _res == 1
         else:
@@ -133,6 +134,7 @@ class TestWithSampleDBAndThreadPool:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 ).result()
                 assert isinstance(_res, list)
 

--- a/tests/test_e2e/test_with_sample_db.py
+++ b/tests/test_e2e/test_with_sample_db.py
@@ -108,6 +108,7 @@ class TestWithSampleDB:
                 _res = self.orm_inst.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 )
                 assert _res == 1
         else:
@@ -116,6 +117,7 @@ class TestWithSampleDB:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
+                    _limit=1,
                 )
                 assert isinstance(_res, Generator)
 


### PR DESCRIPTION
## Introduction

This PR fixes `table_spec.table_delete_stmt` API generating incorrect sql stmt when using both LIMIT and RETURNING, see the correct graph at chapter 3 at https://www.sqlite.org/lang_delete.html.