### PR TITLE
refactor: orm: re-implement orm_select_all_entries_with_pagination; table_spec: add table_from_tuple API

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -230,3 +230,6 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         )
 
     orm_insert_entry.__doc__ = ORMBase.orm_insert_entry.__doc__
+
+    def orm_select_all_with_pagination(self, *, batch_size: int):
+        raise NotImplementedError

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -458,7 +458,7 @@ class ORMBase(Generic[TableSpecType]):
             raise ValueError("batch_size must be positive integer")
 
         _sql_stmt = self.orm_table_spec.table_select_stmt(
-            select_cols=("rowid", "*"),
+            select_cols="rowid,*",
             select_from=self.orm_table_name,
             where_stmt="WHERE rowid > :not_before",
             limit=batch_size,

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -437,23 +437,15 @@ class ORMBase(Generic[TableSpecType]):
                 _cur = con.execute(delete_stmt, cols_value)
                 return _cur.rowcount
 
-    def orm_select_all_entries(
-        self,
-        *,
-        batch_size: int | None = None,
-        _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
-        _row_factory: RowFactoryType | None = None,
+    def orm_select_all_with_pagination(
+        self, *, batch_size: int
     ) -> Generator[TableSpecType, None, None]:
-        """Select all entries from the table accordingly, optionally with pagination.
+        """Select all entries from the table accordingly with pagination.
+
+        This is implemented by seek with rowid, so it will not work on without_rowid table.
 
         Args:
-            batch_size (int | None, optional): If specified, enable pagination and specify the number of entries for each page. Defaults to None.
-            _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
-            _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
-                Order the result accordingly. Defaults to None, not sorting the result.
-            _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
-                as row factory, set this argument to use different row factory. Defaults to None.
+            batch_size (int): The entry number for each page.
 
         Raises:
             ValueError on invalid batch_size.
@@ -462,27 +454,32 @@ class ORMBase(Generic[TableSpecType]):
         Yields:
             Generator[TableSpecType, None, None]: A generator that can be used to yield entry from result.
         """
-        if batch_size is not None and batch_size < 0:
+        if batch_size < 0:
             raise ValueError("batch_size must be positive integer")
 
-        for _batch_idx in count():
-            with self._con as con:
-                _cur = con.execute(
-                    self.orm_table_spec.table_select_all_stmt(
-                        select_from=self.orm_table_name,
-                        distinct=_distinct,
-                        order_by=_order_by,
-                        batch_size=batch_size,
-                        batch_idx=_batch_idx,
-                    )
-                )
-                if _row_factory:
-                    _cur.row_factory = _row_factory
+        _sql_stmt = self.orm_table_spec.table_select_stmt(
+            select_cols=("rowid", "*"),
+            select_from=self.orm_table_name,
+            where_stmt="WHERE rowid > :not_before",
+            limit=batch_size,
+        )
+        _tuple_factory = self.orm_table_spec.table_from_tuple
 
-                if not (_one := _cur.fetchone()):
-                    break
-                yield _one
-                yield from _cur
+        not_before = 0
+        for _ in count():
+            with self._con as con:
+                _cur = con.execute(_sql_stmt, {"not_before": not_before})
+                _cur.row_factory = None
+
+                rowid = -1
+                _row_tuple: tuple[int, ...]
+                for _row_tuple in _cur:
+                    rowid, *_raw_entry = _row_tuple
+                    yield _tuple_factory(_raw_entry)
+
+                if rowid < 0:
+                    return
+                not_before = rowid
 
 
 ORMBaseType = TypeVar("ORMBaseType", bound=ORMBase)

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -20,6 +20,7 @@ from typing_extensions import ParamSpec, deprecated
 from simple_sqlite3_orm._orm._base import ORMBase
 from simple_sqlite3_orm._sqlite_spec import INSERT_OR
 from simple_sqlite3_orm._table_spec import TableSpecType
+from simple_sqlite3_orm._types import RowFactoryType
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +202,24 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
 
         return self._pool.submit(_inner)
 
+    def orm_select_entry(
+        self,
+        *,
+        _distinct: bool = False,
+        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
+        _row_factory: RowFactoryType | None = None,
+        **col_values: Any,
+    ) -> Future[TableSpecType | Any | None]:
+        return self._pool.submit(
+            super().orm_select_entry,
+            _distinct=_distinct,
+            _order_by=_order_by,
+            _row_factory=_row_factory,
+            **col_values,
+        )
+
+    orm_select_entry.__doc__ = ORMBase.orm_select_entry.__doc__
+
     def orm_insert_entries(
         self, _in: Iterable[TableSpecType], *, or_option: INSERT_OR | None = None
     ) -> Future[int]:
@@ -240,3 +259,8 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         return self._pool.submit(_inner)
 
     orm_delete_entries.__doc__ = ORMBase.orm_delete_entries.__doc__
+
+    def orm_select_all_with_pagination(
+        self, *, batch_size: int
+    ) -> Generator[TableSpecType, None, None]:
+        raise NotImplementedError

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -260,7 +260,5 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
 
     orm_delete_entries.__doc__ = ORMBase.orm_delete_entries.__doc__
 
-    def orm_select_all_with_pagination(
-        self, *, batch_size: int
-    ) -> Generator[TableSpecType, None, None]:
+    def orm_select_all_with_pagination(self, *, batch_size: int):
         raise NotImplementedError

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -353,7 +353,7 @@ class TableSpec(BaseModel):
         cls,
         *,
         select_from: str,
-        select_cols: tuple[str, ...] | Literal["*"] = "*",
+        select_cols: tuple[str, ...] | Literal["*"] | str = "*",
         function: SQLiteBuiltInFuncs | None = None,
         where_stmt: str | None = None,
         where_cols: tuple[str, ...] | None = None,
@@ -370,7 +370,7 @@ class TableSpec(BaseModel):
 
         Args:
             select_from (str): The table name for the generated statement.
-            select_cols (tuple[str, ...] | Literal[, optional): A list of cols included in the result row. Defaults to "*".
+            select_cols (tuple[str, ...] | Literal["*"] | str, optional): A list of cols included in the result row. Defaults to "*".
             function (SQLiteBuiltInFuncs | None, optional): The sqlite3 function used in the selection. Defaults to None.
             where_cols (tuple[str, ...] | None, optional): A list of cols to be compared in where
                 statement. Defaults to None.
@@ -391,7 +391,7 @@ class TableSpec(BaseModel):
             cls.table_check_cols(select_cols)
             select_target = ",".join(select_cols)
         else:
-            select_target = "*"
+            select_target = select_cols
 
         if function:
             select_target = f"{function}({select_target})"

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from io import StringIO
-from typing import Any, Literal, TypeVar
+from typing import Any, Iterable, Literal, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -229,7 +229,7 @@ class TableSpec(BaseModel):
         return cls.model_validate(dict(zip(_fields, _row)))
 
     @classmethod
-    def table_from_tuple(cls, _row: tuple[Any, ...]) -> Self:
+    def table_from_tuple(cls, _row: Iterable[Any]) -> Self:
         """A raw row_factory that converts the input _row to TableSpec instance.
 
         Args:

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -229,6 +229,18 @@ class TableSpec(BaseModel):
         return cls.model_validate(dict(zip(_fields, _row)))
 
     @classmethod
+    def table_from_tuple(cls, _row: tuple[Any, ...]) -> Self:
+        """A raw row_factory that converts the input _row to TableSpec instance.
+
+        Args:
+            _row (tuple[Any, ...]): the raw table row as tuple.
+
+        Returns:
+            An instance of self.
+        """
+        return cls.model_validate(dict(zip(cls.model_fields, _row)))
+
+    @classmethod
     @lru_cache
     def table_insert_stmt(
         cls,

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -53,6 +53,13 @@ class TestORMBase:
             orm_inst = ORMTest(conn, table_name=TABLE_NAME)
             yield orm_inst
 
+    def test_create_without_rowid_table(self):
+        """NOTE: to test select_all_with_pagination, we cannot specify without_rowid, so we
+        create this test case dedicated for creating without_rowid table test."""
+        with sqlite3.connect(":memory") as conn:
+            orm_inst = ORMTest(conn, table_name=TABLE_NAME)
+            orm_inst.orm_create_table(without_rowid=True)
+
     def test_create_table(self, setup_connection: ORMTest):
         setup_connection.orm_create_table(allow_existed=False)
 
@@ -61,11 +68,9 @@ class TestORMBase:
                 "STRICT table option is only available after sqlite3 version 3.37, "
                 f"get {sqlite3.sqlite_version_info}, skip testing STRICT table option."
             )
-            setup_connection.orm_create_table(allow_existed=True, without_rowid=True)
+            setup_connection.orm_create_table(allow_existed=True)
         else:
-            setup_connection.orm_create_table(
-                allow_existed=True, strict=True, without_rowid=True
-            )
+            setup_connection.orm_create_table(allow_existed=True, strict=True)
 
         with pytest.raises(sqlite3.DatabaseError):
             setup_connection.orm_create_table(allow_existed=False)

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -119,10 +119,8 @@ class TestORMBase:
         assert select_result[0] == entry_for_test
 
     def test_select_all_entries(self, setup_connection: ORMTest):
-        select_result = setup_connection.orm_select_all_entries(
-            batch_size=SELECT_ALL_BATCH_SIZE,
-            _distinct=True,
-            _order_by=(("key_id", "DESC"),),
+        select_result = setup_connection.orm_select_all_with_pagination(
+            batch_size=SELECT_ALL_BATCH_SIZE
         )
         select_result = list(select_result)
 

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -56,7 +56,7 @@ class TestORMBase:
     def test_create_without_rowid_table(self):
         """NOTE: to test select_all_with_pagination, we cannot specify without_rowid, so we
         create this test case dedicated for creating without_rowid table test."""
-        with sqlite3.connect(":memory") as conn:
+        with sqlite3.connect(":memory:") as conn:
             orm_inst = ORMTest(conn, table_name=TABLE_NAME)
             orm_inst.orm_create_table(without_rowid=True)
 

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -32,7 +32,7 @@ class TestWithSampleDB:
 
     def test_create_table(self):
         logger.info("test create table")
-        self.orm_inst.orm_create_table(without_rowid=True)
+        self.orm_inst.orm_create_table()
         assert utils.lookup_table(self.orm_inst.orm_con, self.orm_inst.orm_table_name)
 
     def test_insert_entries(self, setup_test_data: dict[str, SampleTable]):

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -97,10 +97,8 @@ class TestWithSampleDB:
     def test_select_all_entries(self, setup_test_data: dict[str, SampleTable]):
         logger.info("test lookup entries")
         for _cnt, _entry in enumerate(
-            self.orm_inst.orm_select_all_entries(
-                batch_size=SELECT_ALL_BATCH_SIZE,
-                _distinct=True,
-                _order_by=(("prim_key", "ASC"),),
+            self.orm_inst.orm_select_all_with_pagination(
+                batch_size=SELECT_ALL_BATCH_SIZE
             ),
             start=1,
         ):


### PR DESCRIPTION
## Introduction

This PR introduces following major changes:
1. orm_base: re-implement orm_select_all_entries_with_pagination(renamed from orm_select_all_entries) with seek by rowid.
2. table_spec: add table_from_tuple API to convert a raw tuple(directly queried from database) into instance of TableSpec type.

Other minor changes include:
1. table_spec: table_select_stmt now takes raw select_stmt by allowing str as select_cols arg.
2. orm_thread: add the missing orm_select_entry API.
3. orm_async/orm_threadpool: mock away unsupported API.