### PR TITLE
feat: add some helpers into simple_sqlite3_orm.utils

### DIFF
--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from simple_sqlite3_orm._orm import AsyncORMThreadPoolBase, ORMBase, ORMThreadPoolBase
+from simple_sqlite3_orm._orm import (
+    AsyncORMThreadPoolBase,
+    ORMBase,
+    ORMBaseType,
+    ORMThreadPoolBase,
+)
 from simple_sqlite3_orm._sqlite_spec import (
     SQLiteBuiltInFuncs,
     SQLiteStorageClass,
@@ -8,7 +13,7 @@ from simple_sqlite3_orm._sqlite_spec import (
     SQLiteTypeAffinity,
     SQLiteTypeAffinityLiteral,
 )
-from simple_sqlite3_orm._table_spec import TableSpec, gen_sql_stmt
+from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType, gen_sql_stmt
 from simple_sqlite3_orm._types import (
     DatetimeISO8601,
     DatetimeUnixTimestamp,
@@ -25,8 +30,10 @@ __all__ = [
     "SQLiteTypeAffinityLiteral",
     "TypeAffinityRepr",
     "TableSpec",
+    "TableSpecType",
     "AsyncORMThreadPoolBase",
     "ORMBase",
+    "ORMBaseType",
     "ORMThreadPoolBase",
     "DatetimeISO8601",
     "DatetimeUnixTimestamp",

--- a/src/simple_sqlite3_orm/_orm/__init__.py
+++ b/src/simple_sqlite3_orm/_orm/__init__.py
@@ -1,5 +1,5 @@
 from simple_sqlite3_orm._orm._async import AsyncORMThreadPoolBase
-from simple_sqlite3_orm._orm._base import ORMBase
+from simple_sqlite3_orm._orm._base import ORMBase, ORMBaseType
 from simple_sqlite3_orm._orm._multi_thread import ORMThreadPoolBase
 
-__all__ = ["AsyncORMThreadPoolBase", "ORMBase", "ORMThreadPoolBase"]
+__all__ = ["AsyncORMThreadPoolBase", "ORMBase", "ORMThreadPoolBase", "ORMBaseType"]

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from io import StringIO
 from typing import Any, Iterable, Literal, TypeVar
 
 from pydantic import BaseModel
@@ -15,21 +14,14 @@ from simple_sqlite3_orm._sqlite_spec import (
     SQLiteBuiltInFuncs,
     SQLiteStorageClass,
 )
-from simple_sqlite3_orm._utils import ConstrainRepr, TypeAffinityRepr, lru_cache
+from simple_sqlite3_orm._utils import (
+    ConstrainRepr,
+    TypeAffinityRepr,
+    gen_sql_stmt,
+    lru_cache,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def gen_sql_stmt(*stmts: str) -> str:
-    """Generate statement with input statement strings."""
-    with StringIO() as buffer:
-        for stmt in stmts:
-            if not stmt:
-                continue
-            buffer.write(" ")
-            buffer.write(stmt)
-        buffer.write(";")
-        return buffer.getvalue().strip()
 
 
 class TableSpec(BaseModel):

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -120,10 +120,10 @@ class ConstrainRepr(str):
 def gen_sql_stmt(*components: str) -> str:
     """Combine each components into a single sql stmt."""
     with StringIO() as buffer:
-        for stmt in components:
-            if not stmt:
+        for comp in components:
+            if not comp:
                 continue
             buffer.write(" ")
-            buffer.write(stmt)
+            buffer.write(comp)
         buffer.write(";")
         return buffer.getvalue().strip()

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -115,3 +115,15 @@ class ConstrainRepr(str):
                     _buffer.write(arg)
                 _buffer.write(" ")
             return str.__new__(cls, _buffer.getvalue().strip())
+
+
+def gen_sql_stmt(*stmts: str) -> str:
+    """Generate statement with input statement strings."""
+    with StringIO() as buffer:
+        for stmt in stmts:
+            if not stmt:
+                continue
+            buffer.write(" ")
+            buffer.write(stmt)
+        buffer.write(";")
+        return buffer.getvalue().strip()

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -117,10 +117,10 @@ class ConstrainRepr(str):
             return str.__new__(cls, _buffer.getvalue().strip())
 
 
-def gen_sql_stmt(*stmts: str) -> str:
-    """Generate statement with input statement strings."""
+def gen_sql_stmt(*components: str) -> str:
+    """Combine each components into a single sql stmt."""
     with StringIO() as buffer:
-        for stmt in stmts:
+        for stmt in components:
             if not stmt:
                 continue
             buffer.write(" ")

--- a/src/simple_sqlite3_orm/utils.py
+++ b/src/simple_sqlite3_orm/utils.py
@@ -3,13 +3,28 @@
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import sys
 from enum import Enum
+from io import StringIO
 from itertools import islice
-from typing import Any, Generator, Iterable, Literal, get_args, get_origin, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generator,
+    Iterable,
+    Literal,
+    get_args,
+    get_origin,
+    overload,
+)
 
 from simple_sqlite3_orm._sqlite_spec import COMPARE_OPERATORS, CONDITION_OPERATORS
+
+if TYPE_CHECKING:
+    from simple_sqlite3_orm._orm import ORMBase
+    from simple_sqlite3_orm._table_spec import TableSpec
 
 logger = logging.getLogger(__name__)
 
@@ -310,3 +325,49 @@ def wrap_value(value: Any) -> str:
     if value is None:
         return "NULL"
     raise TypeError("only accept int, float, str, None or bytes")
+
+
+def gen_sql_script(*stmts: str) -> str:
+    """Combine multiple sql statements into a sql script."""
+    with StringIO() as buffer:
+        for stmt in stmts:
+            if not stmt:
+                continue
+            buffer.write(" ")
+            buffer.write(stmt.strip(";"))
+            buffer.write(";")
+        return buffer.getvalue().strip()
+
+
+#
+# ------ advanced helper tools ------ #
+#
+
+
+def sort_and_replace(
+    _orm: ORMBase[TableSpec], table_name: str, *, order_by_col: str
+) -> None:
+    """Sort the table, and then replace the old table with the sorted one."""
+    _original_table_name = table_name
+    _sorted_table_name = f"{table_name}_sorted_{os.urandom(2).hex()}"
+    _table_spec = _orm.orm_table_spec
+
+    _table_create_stmt = _table_spec.table_create_stmt(_sorted_table_name)
+    _table_select_stmt = _table_spec.table_select_stmt(
+        select_from=_original_table_name, order_by=(order_by_col,)
+    )
+    _dump_sorted = f"INSERT INTO {_sorted_table_name} {_table_select_stmt}"
+
+    conn = _orm.orm_con
+    with conn as conn:
+        conn.executescript(
+            gen_sql_script(
+                "BEGIN;",
+                _table_create_stmt,
+                _dump_sorted,
+                f"DROP TABLE {_original_table_name};",
+                f"ALTER TABLE {_sorted_table_name} RENAME TO {_original_table_name};",
+            )
+        )
+    with conn as conn:
+        conn.execute("VACUUM;")


### PR DESCRIPTION
Other changes include:
1. move gen_sql_stmt to simple_sqlite3_orm._utils module.
2. expose TableSpecType and ORMBaseType.