### PR TITLE
feat: table_spec: add new table_from_dict and table_dump_astuple APIs, update table_dump_* and table_from_* methods signature

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -102,7 +102,7 @@ class ORMBase(Generic[TableSpecType]):
     def orm_con(self) -> sqlite3.Connection:
         """A reference to the underlying sqlite3.Connection.
 
-        This is for advanced database execution.
+        This is for directly executing sql stmts.
         """
         return self._con
 

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -224,14 +224,15 @@ class TableSpec(BaseModel):
             _row (tuple[Any, ...]): the raw table row as tuple.
             with_validation (bool): if set to False, will use pydantic model_construct to directly
                 construct instance without validation. Default to True.
-            **kwargs: extra kwargs passed to pydantic model_validate API.
+            **kwargs: extra kwargs passed to pydantic model_validate API. Note that only when
+                with_validation is True, the kwargs will be used.
 
         Returns:
             An instance of self.
         """
         if with_validation:
             return cls.model_validate(dict(zip(cls.model_fields, _row)), **kwargs)
-        return cls.model_construct(**dict(zip(cls.model_fields, _row)), **kwargs)
+        return cls.model_construct(**dict(zip(cls.model_fields, _row)))
 
     @classmethod
     def table_from_dict(
@@ -242,15 +243,16 @@ class TableSpec(BaseModel):
         Args:
             _map (Mapping[str, Any]): the raw table row as a dict.
             with_validation (bool, optional): if set to False, will use pydantic model_construct to directly
-                construct instance without validation. Default to True.. Defaults to True.
-            **kwargs: extra kwargs passed to pydantic model_validate API.
+                construct instance without validation. Default to True.
+            **kwargs: extra kwargs passed to pydantic model_validate API. Note that only when
+                with_validation is True, the kwargs will be used.
 
         Returns:
             An instance of self.
         """
         if with_validation:
             return cls.model_validate(_map, **kwargs)
-        return cls.model_construct(**_map, **kwargs)
+        return cls.model_construct(**_map)
 
     @classmethod
     @lru_cache

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -12,7 +12,6 @@ from simple_sqlite3_orm._sqlite_spec import (
     INSERT_OR,
     ORDER_DIRECTION,
     SQLiteBuiltInFuncs,
-    SQLiteStorageClass,
 )
 from simple_sqlite3_orm._utils import (
     ConstrainRepr,

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -529,13 +529,17 @@ class TableSpec(BaseModel):
     def table_dump_astuple(self, *cols: str, **kwargs) -> tuple[Any, ...]:
         """Dump self's values as a tuple, containing all cols or specified cols.
 
-        This method just wraps the table_dump_asdict method, parse the result dict
-            and return the values of the dict as tuple.
+        This method is basically the same as table_dump_asdict, but instead return a
+            tuple of the dumped values.
 
         Returns:
             A tuple of dumped col values.
         """
-        return tuple(self.table_dump_asdict(*cols, **kwargs).values())
+        try:
+            _included_cols = set(cols) if cols else None
+            return tuple(self.model_dump(include=_included_cols, **kwargs).values())
+        except Exception as e:
+            raise ValueError(f"failed to dump as tuple: {e!r}") from e
 
 
 TableSpecType = TypeVar("TableSpecType", bound=TableSpec)

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Any, Iterable, Literal, TypeVar
+from typing import Any, Iterable, Literal, Mapping, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -221,16 +221,40 @@ class TableSpec(BaseModel):
         return cls.model_validate(dict(zip(_fields, _row)))
 
     @classmethod
-    def table_from_tuple(cls, _row: Iterable[Any]) -> Self:
+    def table_from_tuple(
+        cls, _row: Iterable[Any], *, with_validation: bool = True
+    ) -> Self:
         """A raw row_factory that converts the input _row to TableSpec instance.
 
         Args:
             _row (tuple[Any, ...]): the raw table row as tuple.
+            with_validation (bool): if set to False, will use pydantic model_construct to directly
+                construct instance without validation. Default to True.
 
         Returns:
             An instance of self.
         """
-        return cls.model_validate(dict(zip(cls.model_fields, _row)))
+        if with_validation:
+            return cls.model_validate(dict(zip(cls.model_fields, _row)))
+        return cls.model_construct(**dict(zip(cls.model_fields, _row)))
+
+    @classmethod
+    def table_from_dict(
+        cls, _map: Mapping[str, Any], *, with_validation: bool = True
+    ) -> Self:
+        """A raw row_factory that converts the input mapping to TableSpec instance.
+
+        Args:
+            _map (Mapping[str, Any]): the raw table row as a dict.
+            with_validation (bool, optional): if set to False, will use pydantic model_construct to directly
+                construct instance without validation. Default to True.. Defaults to True.
+
+        Returns:
+            An instance of self.
+        """
+        if with_validation:
+            return cls.model_validate(_map)
+        return cls.model_construct(**_map)
 
     @classmethod
     @lru_cache

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import logging
 import sqlite3
-from typing import Any, Iterable, Literal, Mapping, TypeVar
+from collections.abc import Mapping
+from typing import Any, Iterable, Literal, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -20,8 +20,6 @@ from simple_sqlite3_orm._utils import (
     gen_sql_stmt,
     lru_cache,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class TableSpec(BaseModel):
@@ -118,7 +116,6 @@ class TableSpec(BaseModel):
             raise ValueError("data affinity must be set")
 
         res = f"{column_name} {datatype_name} {constrain}".strip()
-        logger.debug(f"{column_name=}: {res}")
         return res
 
     @classmethod
@@ -154,7 +151,6 @@ class TableSpec(BaseModel):
             f"{table_name} ({cols_spec})",
             f"{','.join(table_options)}",
         )
-        logger.debug(res)
         return res
 
     @classmethod
@@ -198,7 +194,6 @@ class TableSpec(BaseModel):
             f"{index_name}",
             f"ON {table_name} {indexed_columns_stmt}",
         )
-        logger.debug(res)
         return res
 
     @classmethod
@@ -314,7 +309,6 @@ class TableSpec(BaseModel):
             gen_insert_value_stmt,
             gen_returning_stmt,
         )
-        logger.debug(res)
         return res
 
     @classmethod
@@ -372,7 +366,6 @@ class TableSpec(BaseModel):
             gen_order_by_stmt,
             gen_pagination,
         )
-        logger.debug(res)
         return res
 
     @classmethod
@@ -439,7 +432,6 @@ class TableSpec(BaseModel):
             gen_order_by_stmt,
             gen_limit_stmt,
         )
-        logger.debug(res)
         return res
 
     @classmethod
@@ -505,7 +497,6 @@ class TableSpec(BaseModel):
             gen_order_by_stmt,
             gen_limit_stmt,
         )
-        logger.debug(res)
         return res
 
     def table_dump_asdict(self, *cols: str) -> dict[str, SQLiteStorageClass]:

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -216,7 +216,7 @@ class TableSpec(BaseModel):
 
     @classmethod
     def table_from_tuple(
-        cls, _row: Iterable[Any], *, with_validation: bool = True
+        cls, _row: Iterable[Any], *, with_validation: bool = True, **kwargs
     ) -> Self:
         """A raw row_factory that converts the input _row to TableSpec instance.
 
@@ -224,17 +224,18 @@ class TableSpec(BaseModel):
             _row (tuple[Any, ...]): the raw table row as tuple.
             with_validation (bool): if set to False, will use pydantic model_construct to directly
                 construct instance without validation. Default to True.
+            **kwargs: extra kwargs passed to pydantic model_validate API.
 
         Returns:
             An instance of self.
         """
         if with_validation:
-            return cls.model_validate(dict(zip(cls.model_fields, _row)))
-        return cls.model_construct(**dict(zip(cls.model_fields, _row)))
+            return cls.model_validate(dict(zip(cls.model_fields, _row)), **kwargs)
+        return cls.model_construct(**dict(zip(cls.model_fields, _row)), **kwargs)
 
     @classmethod
     def table_from_dict(
-        cls, _map: Mapping[str, Any], *, with_validation: bool = True
+        cls, _map: Mapping[str, Any], *, with_validation: bool = True, **kwargs
     ) -> Self:
         """A raw row_factory that converts the input mapping to TableSpec instance.
 
@@ -242,13 +243,14 @@ class TableSpec(BaseModel):
             _map (Mapping[str, Any]): the raw table row as a dict.
             with_validation (bool, optional): if set to False, will use pydantic model_construct to directly
                 construct instance without validation. Default to True.. Defaults to True.
+            **kwargs: extra kwargs passed to pydantic model_validate API.
 
         Returns:
             An instance of self.
         """
         if with_validation:
-            return cls.model_validate(_map)
-        return cls.model_construct(**_map)
+            return cls.model_validate(_map, **kwargs)
+        return cls.model_construct(**_map, **kwargs)
 
     @classmethod
     @lru_cache

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -67,21 +67,21 @@ def test_table_dump_asdict(_in: SimpleTableForTest, _expected: dict[str, Any]):
 
 
 @pytest.mark.parametrize(
-    "_in, _expected",
+    "_in, _cols, _expected",
     (
         (
             SimpleTableForTest(id=1, id_str="1", extra=1.0),
             ["id", "id_str", "extra"],
-            [1, "1", 1.0],
+            (1, "1", 1.0),
         ),
         (
             SimpleTableForTest(id=1, id_str="1", extra=1.0),
             ["extra"],
-            [1.0],
+            (1.0,),
         ),
     ),
 )
 def test_table_dump_astuple(
-    _in: SimpleTableForTest, _cols: list[str], _expected: tuple[Any, ...]
+    _in: SimpleTableForTest, _cols: tuple[str, ...], _expected: tuple[Any, ...]
 ):
     assert _in.table_dump_astuple(*_cols) == _expected

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -29,24 +29,41 @@ class SimpleTableForTest(TableSpec):
 
 
 @pytest.mark.parametrize(
-    "_in, _expected",
-    (([1, "1", 1.0], SimpleTableForTest(id=1, id_str="1", extra=1.0)),),
+    "_in, _validate, _expected",
+    (
+        ([1, "1", 1.0], True, SimpleTableForTest(id=1, id_str="1", extra=1.0)),
+        ([1, "1", 1.0], False, SimpleTableForTest(id=1, id_str="1", extra=1.0)),
+    ),
 )
-def test_table_from_tuple(_in: Iterable[Any], _expected: SimpleTableForTest):
-    assert SimpleTableForTest.table_from_tuple(_in) == _expected
+def test_table_from_tuple(
+    _in: Iterable[Any], _validate: bool, _expected: SimpleTableForTest
+):
+    assert (
+        SimpleTableForTest.table_from_tuple(_in, with_validation=_validate) == _expected
+    )
 
 
 @pytest.mark.parametrize(
-    "_in, _expected",
+    "_in, _validate, _expected",
     (
         (
             {"id": 1, "id_str": "1", "extra": 1.0},
+            True,
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+        ),
+        (
+            {"id": 1, "id_str": "1", "extra": 1.0},
+            False,
             SimpleTableForTest(id=1, id_str="1", extra=1.0),
         ),
     ),
 )
-def test_table_from_dict(_in: Mapping[str, Any], _expected: SimpleTableForTest):
-    assert SimpleTableForTest.table_from_dict(_in) == _expected
+def test_table_from_dict(
+    _in: Mapping[str, Any], _validate: bool, _expected: SimpleTableForTest
+):
+    assert (
+        SimpleTableForTest.table_from_dict(_in, with_validation=_validate) == _expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Iterable, Optional
+
+import pytest
+from typing_extensions import Annotated
+
+from simple_sqlite3_orm import ConstrainRepr, TableSpec, TypeAffinityRepr
+
+
+class SimpleTableForTest(TableSpec):
+    id: Annotated[
+        int,
+        TypeAffinityRepr(int),
+        ConstrainRepr("PRIMARY KEY"),
+    ]
+
+    id_str: Annotated[
+        str,
+        TypeAffinityRepr(str),
+        ConstrainRepr("NOT NULL"),
+    ]
+
+    extra: Annotated[
+        Optional[float],
+        TypeAffinityRepr(float),
+    ] = None
+
+
+@pytest.mark.parametrize(
+    "_in, _expected",
+    (([1, "1", 1.0], SimpleTableForTest(id=1, id_str="1", extra=1.0)),),
+)
+def test_table_from_tuple(_in: Iterable[Any], _expected: SimpleTableForTest):
+    assert SimpleTableForTest.table_from_tuple(_in) == _expected
+
+
+@pytest.mark.parametrize(
+    "_in, _expected",
+    (
+        (
+            {"id": 1, "id_str": "1", "extra": 1.0},
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+        ),
+    ),
+)
+def test_table_from_dict(_in: Mapping[str, Any], _expected: SimpleTableForTest):
+    assert SimpleTableForTest.table_from_dict(_in) == _expected
+
+
+@pytest.mark.parametrize(
+    "_in, _expected",
+    (
+        (
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+            {"id": 1, "id_str": "1", "extra": 1.0},
+        ),
+        (
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+            {"id": 1, "extra": 1.0},
+        ),
+    ),
+)
+def test_table_dump_asdict(_in: SimpleTableForTest, _expected: dict[str, Any]):
+    assert _in.table_dump_asdict(*_expected) == _expected
+
+
+@pytest.mark.parametrize(
+    "_in, _expected",
+    (
+        (
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+            ["id", "id_str", "extra"],
+            [1, "1", 1.0],
+        ),
+        (
+            SimpleTableForTest(id=1, id_str="1", extra=1.0),
+            ["extra"],
+            [1.0],
+        ),
+    ),
+)
+def test_table_dump_astuple(
+    _in: SimpleTableForTest, _cols: list[str], _expected: tuple[Any, ...]
+):
+    assert _in.table_dump_astuple(*_cols) == _expected


### PR DESCRIPTION
Detailed changes include:
1. table_spec: add table_from_dict and table_dump_astuple APIs.
2. table_spec: now table_from_* APIs take with_validation arg to allow skip pydantic validation when importing.
3. table_spec: table_dump_* and table_from_* APIs now take kwargs, which will be passed to pydantic model_dump API underneath.
4. add tests for the from and dump series APIs.

Other minor changes:
1. table_spec: remove debug loggings from this module.