### PR TITLE
feat: orm_base: add orm_check_entry_exist API

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -498,7 +498,7 @@ class ORMBase(Generic[TableSpecType]):
         )
 
         with self._con as con:
-            _cur = con.execute(_stmt)
+            _cur = con.execute(_stmt, cols)
             _cur.row_factory = None  # bypass con scope row_factory
             _res: tuple[int] = _cur.fetchone()
             return _res[0] > 0

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import sqlite3
 import sys
 from functools import cached_property
@@ -27,7 +26,6 @@ _parameterized_orm_cache: WeakValueDictionary[
     tuple[type[ORMBase], type[TableSpec]], type[ORMBase[Any]]
 ] = WeakValueDictionary()
 
-logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 RT = TypeVar("RT")
@@ -480,6 +478,30 @@ class ORMBase(Generic[TableSpecType]):
                 if rowid < 0:
                     return
                 not_before = rowid
+
+    def orm_check_entry_exist(self, **cols: Any) -> bool:
+        """A quick method to check whether entry(entries) indicated by cols exists.
+
+        This method uses COUNT function to count the selected entry.
+
+        Args:
+            **cols: cols pair to locate the entry(entries).
+
+        Returns:
+            Returns True if at least one entry matches the input cols exists, otherwise False.
+        """
+        _stmt = self.orm_table_spec.table_select_stmt(
+            select_from=self.orm_table_name,
+            select_cols="*",
+            function="count",
+            where_cols=tuple(cols),
+        )
+
+        with self._con as con:
+            _cur = con.execute(_stmt)
+            _cur.row_factory = None  # bypass con scope row_factory
+            _res: tuple[int] = _cur.fetchone()
+            return _res[0] > 0
 
 
 ORMBaseType = TypeVar("ORMBaseType", bound=ORMBase)

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -109,6 +109,7 @@ class TestORMBase:
 
     def test_orm_check_entry_exist(self, setup_connection: ORMTest):
         assert setup_connection.orm_check_entry_exist(prim_key=entry_for_test.prim_key)
+        assert not setup_connection.orm_check_entry_exist(prim_key=Mystr("not_exist"))
 
     def test_select_entry(self, setup_connection: ORMTest):
         assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -107,6 +107,9 @@ class TestORMBase:
         res = setup_connection.orm_execute(sql_stmt)
         assert res and res[0][0] > 0
 
+    def test_orm_check_entry_exist(self, setup_connection: ORMTest):
+        assert setup_connection.orm_check_entry_exist(prim_key=entry_for_test.prim_key)
+
     def test_select_entry(self, setup_connection: ORMTest):
         assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)
 


### PR DESCRIPTION
Add an API for quickly checking whether there is at least one entry that matches the input col value pair(s). This API is implemented with COUNT function, and bypass the connection scope row_factory for better performance.