### PR TITLE
feat: orm: allow specifying row_factory on __init__

### DIFF
--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -18,6 +18,7 @@ from simple_sqlite3_orm._types import (
     DatetimeISO8601,
     DatetimeUnixTimestamp,
     DatetimeUnixTimestampInt,
+    RowFactoryType,
 )
 from simple_sqlite3_orm._utils import ConstrainRepr, TypeAffinityRepr
 
@@ -38,5 +39,6 @@ __all__ = [
     "DatetimeISO8601",
     "DatetimeUnixTimestamp",
     "DatetimeUnixTimestampInt",
+    "RowFactoryType",
     "gen_sql_stmt",
 ]

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -15,6 +15,7 @@ from typing import (
 from typing_extensions import ParamSpec, deprecated
 
 from simple_sqlite3_orm._orm import _multi_thread as _orm_multi_thread
+from simple_sqlite3_orm._orm._base import RowFactorySpecifier
 from simple_sqlite3_orm._orm._multi_thread import ORMBase, ORMThreadPoolBase
 from simple_sqlite3_orm._sqlite_spec import INSERT_OR
 from simple_sqlite3_orm._table_spec import TableSpecType
@@ -26,6 +27,13 @@ RT = TypeVar("RT")
 
 
 class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
+    """
+    NOTE: the supoprt for async ORM is experimental! The APIs might be changed a lot
+        in the following releases.
+
+    For the row_factory arg, please see ORMBase.__init__ for more details.
+    """
+
     def __init__(
         self,
         table_name: str,
@@ -34,6 +42,7 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         con_factory: Callable[[], sqlite3.Connection],
         number_of_cons: int,
         thread_name_prefix: str = "",
+        row_factory: RowFactorySpecifier = "table_spec",
     ) -> None:
         # setup the thread pool
         super().__init__(
@@ -42,6 +51,7 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
             con_factory=con_factory,
             number_of_cons=number_of_cons,
             thread_name_prefix=thread_name_prefix,
+            row_factory=row_factory,
         )
 
         self._loop = asyncio.get_running_loop()

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 import sys
-from functools import cached_property
+from functools import cached_property, partial
 from itertools import count
 from typing import (
     TYPE_CHECKING,
@@ -80,7 +80,7 @@ def row_factory_setter(
     elif row_factory_specifier == "table_spec":
         con.row_factory = table_spec.table_row_factory
     elif row_factory_specifier == "table_spec_no_validation":
-        con.row_factory = table_spec.table_row_factory_no_validation
+        con.row_factory = partial(table_spec.table_row_factory, validation=False)
 
 
 class ORMBase(Generic[TableSpecType]):

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -48,13 +48,13 @@ else:
 
 
 RowFactorySpecifier = Union[
-    RowFactoryType
-    | Literal[
+    RowFactoryType,
+    Literal[
         "sqlite3_row_factory",
         "table_spec",
         "table_spec_no_validation",
-    ]
-    | None
+    ],
+    None,
 ]
 """Specifiy which row_factory to use.
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     Literal,
     TypeVar,
+    Union,
     overload,
 )
 from weakref import WeakValueDictionary
@@ -46,6 +47,42 @@ else:
                 """For type check only, typing the _GenericAlias as GenericAlias."""
 
 
+RowFactorySpecifier = Union[
+    RowFactoryType
+    | Literal[
+        "sqlite3_row_factory",
+        "table_spec",
+        "table_spec_no_validation",
+    ]
+    | None
+]
+"""Specifiy which row_factory to use.
+
+For each option:
+    1. RowFactoryType: specify arbitrary row_factory.
+    2. None: do not set connection scope row_factory.
+    3. "sqlite3_row_factory": set to use sqlite3.Row as row_factory.
+    4. "table_spec": use TableSpec.table_row_factory as row_factory.
+    5. "table_spec_no_validation": use TableSpec.table_row_factory_no_validation as row_factory.
+"""
+
+
+def row_factory_setter(
+    con: sqlite3.Connection,
+    table_spec: type[TableSpec],
+    row_factory_specifier: RowFactorySpecifier,
+) -> None:
+    """Helper function to set connection scope row_factory by row_factory_specifier."""
+    if callable(row_factory_specifier):
+        con.row_factory = row_factory_specifier
+    elif row_factory_specifier == "sqlite3_row_factory":
+        con.row_factory = sqlite3.Row
+    elif row_factory_specifier == "table_spec":
+        con.row_factory = table_spec.table_row_factory
+    elif row_factory_specifier == "table_spec_no_validation":
+        con.row_factory = table_spec.table_row_factory_no_validation
+
+
 class ORMBase(Generic[TableSpecType]):
     """ORM layer for <TableSpecType>.
 
@@ -60,16 +97,7 @@ class ORMBase(Generic[TableSpecType]):
         con (sqlite3.Connection): The sqlite3 connection used by this ORM.
         table_name (str): The name of the table in the database <con> connected to.
         schema_name (str): The schema of the table if multiple databases are attached to <con>.
-        row_factory (RowFactoryType | Literal[
-                "sqlite3_row_factory",
-                "table_spec",
-                "table_spec_no_validation",
-            ] | None): The connection scope row_factory to use. Default to "table_sepc". For each option:
-                1. RowFactoryType: specify arbitrary row_factory.
-                2. None: do not set connection scope row_factory.
-                3. "sqlite3_row_factory": set to use sqlite3.Row as row_factory.
-                4. "table_spec": use TableSpec.table_row_factory as row_factory.
-                5. "table_spec_no_validation": use TableSpec.table_row_factory_no_validation as row_factory.
+        row_factory (RowFactorySpecifier): The connection scope row_factory to use. Default to "table_sepc".
     """
 
     orm_table_spec: type[TableSpecType]
@@ -80,25 +108,12 @@ class ORMBase(Generic[TableSpecType]):
         table_name: str,
         schema_name: str | Literal["temp"] | None = None,
         *,
-        row_factory: RowFactoryType
-        | Literal[
-            "sqlite3_row_factory",
-            "table_spec",
-            "table_spec_no_validation",
-        ] = "table_spec",
+        row_factory: RowFactorySpecifier = "table_spec",
     ) -> None:
         self._table_name = table_name
         self._schema_name = schema_name
         self._con = con
-
-        if callable(row_factory):
-            con.row_factory = row_factory
-        elif row_factory == "sqlite3_row_factory":
-            con.row_factory = sqlite3.Row
-        elif row_factory == "table_spec":
-            con.row_factory = self.orm_table_spec.table_row_factory
-        elif row_factory == "table_spec_no_validation":
-            con.row_factory = self.orm_table_spec.table_row_factory_no_validation
+        row_factory_setter(con, self.orm_table_spec, row_factory)
 
     def __class_getitem__(cls, params: Any | type[Any] | type[TableSpecType]) -> Any:
         # just for convienience, passthrough anything that is not type[TableSpecType]

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -63,7 +63,7 @@ For each option:
     2. None: do not set connection scope row_factory.
     3. "sqlite3_row_factory": set to use sqlite3.Row as row_factory.
     4. "table_spec": use TableSpec.table_row_factory as row_factory.
-    5. "table_spec_no_validation": use TableSpec.table_row_factory_no_validation as row_factory.
+    5. "table_spec_no_validation": use TableSpec.table_row_factory as row_factory, but with validation=False.
 """
 
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -71,16 +71,17 @@ def row_factory_setter(
     con: sqlite3.Connection,
     table_spec: type[TableSpec],
     row_factory_specifier: RowFactorySpecifier,
-) -> None:
+) -> None:  # pragma: no cover
     """Helper function to set connection scope row_factory by row_factory_specifier."""
     if callable(row_factory_specifier):
         con.row_factory = row_factory_specifier
-    elif row_factory_specifier == "sqlite3_row_factory":
-        con.row_factory = sqlite3.Row
     elif row_factory_specifier == "table_spec":
         con.row_factory = table_spec.table_row_factory
     elif row_factory_specifier == "table_spec_no_validation":
         con.row_factory = partial(table_spec.table_row_factory, validation=False)
+    elif row_factory_specifier == "sqlite3_row_factory":
+        con.row_factory = sqlite3.Row
+    # do nothing means not changing connection scope row_factory
 
 
 class ORMBase(Generic[TableSpecType]):

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -197,12 +197,15 @@ class TableSpec(BaseModel):
 
     @classmethod
     def table_row_factory(
-        cls, _cursor: sqlite3.Cursor, _row: tuple[Any, ...]
+        cls, _cursor: sqlite3.Cursor, _row: tuple[Any, ...], *, validation: bool = True
     ) -> Self | tuple[Any, ...]:
         """row_factory implement for used in sqlite3 connection.
 
         When the input <_row> is not a row but something like function output,
             this method will return the raw input tuple as it.
+
+        Args:
+            validation (bool): whether enable pydantic validation when importing row. Default to True.
 
         Also see https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.description
             for more details.
@@ -212,7 +215,10 @@ class TableSpec(BaseModel):
         # when we realize that the input is not a row, but something like function call's output.
         if not all(col in cls.model_fields for col in _fields):
             return _row
-        return cls.model_validate(dict(zip(_fields, _row)))
+
+        if validation:
+            return cls.model_validate(dict(zip(_fields, _row)))
+        return cls.model_construct(**dict(zip(_fields, _row)))
 
     @classmethod
     def table_from_tuple(


### PR DESCRIPTION
Other changes:
1. table_spec: now table_row_factory takes an optional kwarg validation(default to True), to allow optionally disable pydantic validation when importing rows.