### PR TITLE
feat!: orm_threadpool&orm_async: fully re-implement, now fully support all APIs in orm_base

### DIFF
--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from simple_sqlite3_orm._orm import (
-    AsyncORMThreadPoolBase,
+    AsyncORMBase,
     ORMBase,
     ORMBaseType,
     ORMThreadPoolBase,
@@ -32,7 +32,7 @@ __all__ = [
     "TypeAffinityRepr",
     "TableSpec",
     "TableSpecType",
-    "AsyncORMThreadPoolBase",
+    "AsyncORMBase",
     "ORMBase",
     "ORMBaseType",
     "ORMThreadPoolBase",

--- a/src/simple_sqlite3_orm/_orm/__init__.py
+++ b/src/simple_sqlite3_orm/_orm/__init__.py
@@ -1,5 +1,5 @@
-from simple_sqlite3_orm._orm._async import AsyncORMThreadPoolBase
+from simple_sqlite3_orm._orm._async import AsyncORMBase
 from simple_sqlite3_orm._orm._base import ORMBase, ORMBaseType
 from simple_sqlite3_orm._orm._multi_thread import ORMThreadPoolBase
 
-__all__ = ["AsyncORMThreadPoolBase", "ORMBase", "ORMThreadPoolBase", "ORMBaseType"]
+__all__ = ["AsyncORMBase", "ORMBase", "ORMThreadPoolBase", "ORMBaseType"]

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -169,6 +169,21 @@ class AsyncORMThreadPoolBase(Generic[TableSpecType]):
             else self._table_name
         )
 
+    def orm_pool_shutdown(self, *, wait=True, close_connections=True) -> None:
+        """Shutdown the ORM connections thread pool used by this async ORM instance.
+
+        It is safe to call this method multiple time.
+        This method is NOT thread-safe, and should be called at the main thread,
+            or the thread that creates this thread pool.
+
+        Args:
+            wait (bool, optional): Wait for threads join. Defaults to True.
+            close_connections (bool, optional): Close all the connections. Defaults to True.
+        """
+        self._orm_threadpool.orm_pool_shutdown(
+            wait=wait, close_connections=close_connections
+        )
+
     orm_execute = _wrap_with_async_ctx(ORMBase.orm_execute)
     orm_create_table = _wrap_with_async_ctx(ORMBase.orm_create_table)
     orm_create_index = _wrap_with_async_ctx(ORMBase.orm_create_index)

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -1,38 +1,113 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import sqlite3
-from typing import (
-    Any,
-    AsyncGenerator,
-    Callable,
-    Iterable,
-    Literal,
-    TypeVar,
-)
+from collections.abc import AsyncGenerator, Callable, Generator
+from typing import Any, Generic, TypeVar
+from weakref import WeakValueDictionary
 
-from typing_extensions import ParamSpec, deprecated
+from typing_extensions import Concatenate, ParamSpec
 
-from simple_sqlite3_orm._orm import _multi_thread as _orm_multi_thread
 from simple_sqlite3_orm._orm._base import RowFactorySpecifier
 from simple_sqlite3_orm._orm._multi_thread import ORMBase, ORMThreadPoolBase
-from simple_sqlite3_orm._sqlite_spec import INSERT_OR
-from simple_sqlite3_orm._table_spec import TableSpecType
+from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType
+from simple_sqlite3_orm._utils import GenericAlias
 
 logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 RT = TypeVar("RT")
 
+_parameterized_orm_cache: WeakValueDictionary[
+    tuple[type[AsyncORMThreadPoolBase], type[TableSpec]],
+    type[AsyncORMThreadPoolBase[Any]],
+] = WeakValueDictionary()
 
-class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
+_global_shutdown = False
+
+
+def _python_exit():
+    global _global_shutdown
+    _global_shutdown = True
+
+
+atexit.register(_python_exit)
+
+_SENTINEL = object()
+
+
+def _wrap_with_async_ctx(
+    func: Callable[Concatenate[ORMBase, P], RT],
+):
+    async def _wrapped(
+        self: AsyncORMThreadPoolBase, *args: P.args, **kwargs: P.kwargs
+    ) -> RT:
+        _orm_threadpool = self._orm_threadpool
+
+        def _in_thread() -> RT:
+            _orm_base = _orm_threadpool._thread_scope_orm
+            return func(_orm_base, *args, **kwargs)
+
+        return await asyncio.wrap_future(
+            _orm_threadpool._pool.submit(_in_thread),
+            loop=self._loop,
+        )
+
+    _wrapped.__doc__ = func.__doc__
+    return _wrapped
+
+
+def _wrap_generator_with_async_ctx(
+    func: Callable[Concatenate[ORMBase, P], Generator[TableSpecType]],
+):
+    async def _wrapped(self: AsyncORMThreadPoolBase, *args: P.args, **kwargs: P.kwargs):
+        _orm_threadpool = self._orm_threadpool
+        _async_queue = asyncio.Queue()
+
+        def _in_thread():
+            global _global_shutdown
+            _orm_base = _orm_threadpool._thread_scope_orm
+            try:
+                for entry in func(_orm_base, *args, **kwargs):
+                    if _global_shutdown:
+                        return
+                    self._loop.call_soon_threadsafe(_async_queue.put_nowait, entry)
+            except Exception as e:
+                self._loop.call_soon_threadsafe(_async_queue.put_nowait, e)
+            finally:
+                self._loop.call_soon_threadsafe(_async_queue.put_nowait, _SENTINEL)
+
+        self._orm_threadpool._pool.submit(_in_thread)
+
+        async def _gen() -> AsyncGenerator[TableSpecType]:
+            while not _global_shutdown:
+                entry = await _async_queue.get()
+                if entry is _SENTINEL:
+                    return
+
+                if isinstance(entry, Exception):
+                    try:
+                        raise entry
+                    finally:
+                        entry = None
+                yield entry
+
+        return _gen()
+
+    return _wrapped
+
+
+class AsyncORMThreadPoolBase(Generic[TableSpecType]):
     """
     NOTE: the supoprt for async ORM is experimental! The APIs might be changed a lot
         in the following releases.
 
     For the row_factory arg, please see ORMBase.__init__ for more details.
     """
+
+    orm_table_spec: type[TableSpecType]
 
     def __init__(
         self,
@@ -45,7 +120,7 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
         row_factory: RowFactorySpecifier = "table_spec",
     ) -> None:
         # setup the thread pool
-        super().__init__(
+        self._orm_threadpool = ORMThreadPoolBase[self.orm_table_spec](
             table_name,
             schema_name,
             con_factory=con_factory,
@@ -56,189 +131,36 @@ class AsyncORMThreadPoolBase(ORMThreadPoolBase[TableSpecType]):
 
         self._loop = asyncio.get_running_loop()
 
-    def _run_in_pool(
-        self, func: Callable[P, RT], *args: P.args, **kwargs: P.kwargs
-    ) -> asyncio.Future[RT]:
-        """Run normal function in threadpool and track the result async."""
-        return asyncio.wrap_future(
-            self._pool.submit(func, *args, **kwargs),
-            loop=self._loop,
+    def __class_getitem__(cls, params: Any | type[Any] | type[TableSpecType]) -> Any:
+        # just for convienience, passthrough anything that is not type[TableSpecType]
+        #   to Generic's __class_getitem__ and return it.
+        # Typically this is for subscript ORMBase with TypeVar or another Generic.
+        if not (isinstance(params, type) and issubclass(params, TableSpec)):
+            return super().__class_getitem__(params)  # type: ignore
+
+        key = (cls, params)
+        if _cached_type := _parameterized_orm_cache.get(key):
+            return GenericAlias(_cached_type, params)
+
+        new_parameterized_ormbase: type[AsyncORMThreadPoolBase] = type(
+            f"{cls.__name__}[{params.__name__}]", (cls,), {}
         )
+        new_parameterized_ormbase.orm_table_spec = params  # type: ignore
+        _parameterized_orm_cache[key] = new_parameterized_ormbase
+        return GenericAlias(new_parameterized_ormbase, params)
 
-    @property
-    @deprecated("orm_con is not available in thread pool ORM")
-    def orm_con(self):
-        """Not implemented, orm_con is not available in thread pool ORM."""
-        raise NotImplementedError("orm_con is not available in thread pool ORM")
-
-    async def orm_execute(
-        self, sql_stmt: str, params: tuple[Any, ...] | dict[str, Any] | None = None
-    ) -> list[Any]:
-        return await self._run_in_pool(ORMBase.orm_execute, self, sql_stmt, params)
-
-    orm_execute.__doc__ = ORMBase.orm_execute.__doc__
-
-    def orm_select_entries_gen(
-        self,
-        *,
-        _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
-        _limit: int | None = None,
-        **col_values: Any,
-    ) -> AsyncGenerator[TableSpecType, Any]:
-        """Select multiple entries and return an async generator for yielding entries from."""
-        _async_queue = asyncio.Queue()
-
-        def _inner():
-            global _global_shutdown
-            try:
-                for entry in ORMBase.orm_select_entries(
-                    self,
-                    _distinct=_distinct,
-                    _order_by=_order_by,
-                    _limit=_limit,
-                    **col_values,
-                ):
-                    if _orm_multi_thread._global_shutdown:
-                        break
-                    self._loop.call_soon_threadsafe(_async_queue.put_nowait, entry)
-            except Exception as e:
-                self._loop.call_soon_threadsafe(_async_queue.put_nowait, e)
-            finally:
-                self._loop.call_soon_threadsafe(_async_queue.put_nowait, None)
-
-        self._pool.submit(_inner)
-
-        async def _gen():
-            while entry := await _async_queue.get():
-                if isinstance(entry, Exception):
-                    try:
-                        raise entry from None
-                    finally:
-                        del entry
-                yield entry
-
-        return _gen()
-
-    async def orm_select_entries(
-        self,
-        *,
-        _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
-        _limit: int | None = None,
-        **col_values: Any,
-    ) -> list[TableSpecType]:
-        """Select multiple entries and return all the entries in a list."""
-
-        def _inner():
-            return list(
-                ORMBase.orm_select_entries(
-                    self,
-                    _distinct=_distinct,
-                    _order_by=_order_by,
-                    _limit=_limit,
-                    **col_values,
-                )
-            )
-
-        return await self._run_in_pool(_inner)
-
-    async def orm_select_entry(
-        self,
-        *,
-        _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
-        **col_values: Any,
-    ) -> TableSpecType | None:
-        return await self._run_in_pool(
-            ORMBase.orm_select_entry,
-            self,
-            _distinct=_distinct,
-            _order_by=_order_by,
-            **col_values,
-        )
-
-    orm_select_entry.__doc__ = ORMBase.orm_select_entry
-
-    async def orm_delete_entries(
-        self,
-        *,
-        _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]]] | None = None,
-        _limit: int | None = None,
-        _returning_cols: tuple[str, ...] | None | Literal["*"] = None,
-        **cols_value: Any,
-    ) -> list[TableSpecType] | int:
-        # NOTE(20240708): currently we don't support async generator for delete with RETURNING statement
-        def _inner():
-            res = ORMBase.orm_delete_entries(
-                self,
-                _order_by=_order_by,
-                _limit=_limit,
-                _returning_cols=_returning_cols,
-                **cols_value,
-            )
-
-            if isinstance(res, int):
-                return res
-            return list(res)
-
-        return await self._run_in_pool(_inner)
-
-    orm_delete_entries.__doc__ = ORMBase.orm_delete_entries.__doc__
-
-    async def orm_create_table(
-        self,
-        *,
-        allow_existed: bool = False,
-        strict: bool = False,
-        without_rowid: bool = False,
-    ) -> None:
-        return await self._run_in_pool(
-            ORMBase.orm_create_table,
-            self,
-            allow_existed=allow_existed,
-            strict=strict,
-            without_rowid=without_rowid,
-        )
-
-    orm_create_table.__doc__ = ORMBase.orm_create_table.__doc__
-
-    async def orm_create_index(
-        self,
-        *,
-        index_name: str,
-        index_keys: tuple[str, ...],
-        allow_existed: bool = False,
-        unique: bool = False,
-    ) -> None:
-        return await self._run_in_pool(
-            ORMBase.orm_create_index,
-            self,
-            index_name=index_name,
-            index_keys=index_keys,
-            allow_existed=allow_existed,
-            unique=unique,
-        )
-
-    orm_create_index.__doc__ = ORMBase.orm_create_index.__doc__
-
-    async def orm_insert_entries(
-        self, _in: Iterable[TableSpecType], *, or_option: INSERT_OR | None = None
-    ) -> int:
-        return await self._run_in_pool(
-            ORMBase.orm_insert_entries, self, _in, or_option=or_option
-        )
-
-    orm_insert_entries.__doc__ = ORMBase.orm_insert_entries.__doc__
-
-    async def orm_insert_entry(
-        self, _in: TableSpecType, *, or_option: INSERT_OR | None = None
-    ) -> int:
-        return await self._run_in_pool(
-            ORMBase.orm_insert_entry, self, _in, or_option=or_option
-        )
-
-    orm_insert_entry.__doc__ = ORMBase.orm_insert_entry.__doc__
-
-    def orm_select_all_with_pagination(self, *, batch_size: int):
-        raise NotImplementedError
+    orm_execute = _wrap_with_async_ctx(ORMBase.orm_execute)
+    orm_create_table = _wrap_with_async_ctx(ORMBase.orm_create_table)
+    orm_create_index = _wrap_with_async_ctx(ORMBase.orm_create_index)
+    orm_select_entries = _wrap_generator_with_async_ctx(ORMBase.orm_select_entries)
+    orm_select_entry = _wrap_with_async_ctx(ORMBase.orm_select_entry)
+    orm_insert_entries = _wrap_with_async_ctx(ORMBase.orm_insert_entries)
+    orm_insert_entry = _wrap_with_async_ctx(ORMBase.orm_insert_entry)
+    orm_delete_entries = _wrap_with_async_ctx(ORMBase.orm_delete_entries)
+    orm_delete_entries_with_returning = _wrap_generator_with_async_ctx(
+        ORMBase.orm_delete_entries_with_returning
+    )
+    orm_select_all_with_pagination = _wrap_generator_with_async_ctx(
+        ORMBase.orm_select_all_with_pagination
+    )
+    orm_check_entry_exist = _wrap_with_async_ctx(ORMBase.orm_check_entry_exist)

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -156,7 +156,7 @@ class ORMBase(Generic[TableSpecType]):
 
     def orm_execute(
         self, sql_stmt: str, params: tuple[Any, ...] | dict[str, Any] | None = None
-    ) -> list[TableSpecType | Any]:
+    ) -> list[Any]:
         """Execute one sql statement and get the all the result.
 
         The result will be fetched with fetchall API and returned as it.

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -13,7 +13,6 @@ from typing import (
     Literal,
     TypeVar,
     Union,
-    overload,
 )
 from weakref import WeakValueDictionary
 

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -151,12 +151,10 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
     orm_execute = _wrap_with_thread_ctx(ORMBase.orm_execute)
     orm_create_table = _wrap_with_thread_ctx(ORMBase.orm_create_table)
     orm_create_index = _wrap_with_thread_ctx(ORMBase.orm_create_index)
-
     orm_select_entries = _wrap_generator_with_thread_ctx(ORMBase.orm_select_entries)
     orm_select_entry = _wrap_with_thread_ctx(ORMBase.orm_select_entry)
     orm_insert_entries = _wrap_with_thread_ctx(ORMBase.orm_insert_entries)
     orm_insert_entry = _wrap_with_thread_ctx(ORMBase.orm_insert_entry)
-
     orm_delete_entries = _wrap_with_thread_ctx(ORMBase.orm_delete_entries)
     orm_delete_entries_with_returning = _wrap_generator_with_thread_ctx(
         ORMBase.orm_delete_entries_with_returning

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -157,23 +157,10 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
     orm_insert_entries = _wrap_with_thread_ctx(ORMBase.orm_insert_entries)
     orm_insert_entry = _wrap_with_thread_ctx(ORMBase.orm_insert_entry)
 
-    _orm_delete_entries_with_returning = _wrap_generator_with_thread_ctx(
-        ORMBase.orm_delete_entries
+    orm_delete_entries = _wrap_with_thread_ctx(ORMBase.orm_delete_entries)
+    orm_delete_entries_with_returning = _wrap_generator_with_thread_ctx(
+        ORMBase.orm_delete_entries_with_returning
     )
-    _orm_delete_entries = _wrap_with_thread_ctx(ORMBase.orm_delete_entries)
-
-    @wraps(ORMBase.orm_delete_entries)
-    def orm_delete_entries(
-        self,
-        *args,
-        **kwargs,
-    ):
-        # NOTE: also seee orm_base for more details about overloaded orm_delete_entries API.
-        _returning_cols = kwargs.get("_returning_cols", None)
-        if _returning_cols:
-            return self._orm_delete_entries_with_returning(*args, **kwargs)
-        return self._orm_delete_entries(*args, **kwargs)
-
     orm_select_all_with_pagination = _wrap_generator_with_thread_ctx(
         ORMBase.orm_select_all_with_pagination
     )

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -162,7 +162,7 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         _order_by: tuple[str | tuple[str, Literal["ASC", "DESC"]], ...] | None = None,
         _limit: int | None = None,
         **col_values: Any,
-    ) -> Future[list[TableSpecType]]:
+    ) -> list[TableSpecType]:
         """Select multiple entries and return all the entries in a list."""
 
         def _inner():
@@ -176,7 +176,7 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
                 )
             )
 
-        return self._pool.submit(_inner)
+        return self._pool.submit(_inner).result()
 
     orm_select_entry = _wrap_with_thread_ctx(ORMBase.orm_select_entry)
     orm_insert_entries = _wrap_with_thread_ctx(ORMBase.orm_insert_entries)

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -5,7 +5,7 @@ import logging
 import queue
 import sqlite3
 import threading
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
 from typing import (
     Any,
@@ -189,7 +189,7 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
         _limit: int | None = None,
         _returning_cols: tuple[str, ...] | None | Literal["*"] = None,
         **cols_value: Any,
-    ) -> Future[int | list[TableSpecType]]:
+    ) -> int | list[TableSpecType]:
         # NOTE(20240708): currently we don't support generator for delete with RETURNING statement
         def _inner():
             res = ORMBase.orm_delete_entries(
@@ -204,7 +204,7 @@ class ORMThreadPoolBase(ORMBase[TableSpecType]):
                 return res
             return list(res)
 
-        return self._pool.submit(_inner)
+        return self._pool.submit(_inner).result()
 
     orm_delete_entries.__doc__ = ORMBase.orm_delete_entries.__doc__
 

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from io import StringIO
 from typing import (
     TYPE_CHECKING,
@@ -31,6 +32,22 @@ if TYPE_CHECKING:
 
 else:
     from functools import lru_cache  # noqa: F401
+
+
+if sys.version_info >= (3, 9):
+    from types import GenericAlias
+else:
+    from typing import List
+
+    if not TYPE_CHECKING:
+        GenericAlias = type(List[int])
+    else:
+
+        class GenericAlias(type(List)):
+            def __new__(
+                cls, _type: type[Any], _params: type[Any] | tuple[type[Any], ...]
+            ):
+                """For type check only, typing the _GenericAlias as GenericAlias."""
 
 
 class TypeAffinityRepr(str):

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -86,7 +86,7 @@ class TestWithSampleDBWithAsyncIO:
 
         logger.info("confirm data written with orm_select_entries_gen")
         _count = 0
-        async for _entry in async_pool.orm_select_entries_gen():
+        async for _entry in await async_pool.orm_select_entries():
             _corresponding_item = setup_test_data[_entry.prim_key]
             assert _corresponding_item == _entry
             _count += 1
@@ -109,8 +109,13 @@ class TestWithSampleDBWithAsyncIO:
                 key_id=_entry.key_id,
                 prim_key_sha256hash=_entry.prim_key_sha256hash,
             )
-            assert len(_looked_up) == 1
-            assert _looked_up[0] == _entry
+
+            _looked_up_list = []
+            async for _item in _looked_up:
+                _looked_up_list.append(_item)
+
+            assert len(_looked_up_list) == 1
+            assert _looked_up_list[0] == _entry
 
     async def test_orm_execute(
         self, async_pool: SampleDBAsyncio, setup_test_data: dict[str, SampleTable]

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -151,7 +151,7 @@ class TestWithSampleDBWithAsyncIO:
                 assert _res == 1
         else:
             for entry in entries_to_remove:
-                _res = await async_pool.orm_delete_entries(
+                _res = await async_pool.orm_delete_entries_with_returning(
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -9,7 +9,7 @@ from typing import Callable
 import pytest
 import pytest_asyncio
 
-from simple_sqlite3_orm._orm import AsyncORMThreadPoolBase
+from simple_sqlite3_orm._orm import AsyncORMBase
 from simple_sqlite3_orm.utils import batched
 from tests.conftest import INDEX_KEYS, INDEX_NAME, TABLE_NAME, TEST_INSERT_BATCH_SIZE
 from tests.sample_db.table import SampleTable
@@ -22,7 +22,7 @@ THREAD_NUM = 2
 TIMER_INTERVAL = 0.1
 
 
-class SampleDBAsyncio(AsyncORMThreadPoolBase[SampleTable]):
+class SampleDBAsyncio(AsyncORMBase[SampleTable]):
     """Test connection pool with async API."""
 
 

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -157,10 +157,13 @@ class TestWithSampleDBWithAsyncIO:
                     prim_key_sha256hash=entry.prim_key_sha256hash,
                     _limit=1,
                 )
-                assert isinstance(_res, list)
 
-                assert len(_res) == 1
-                assert _res[0] == entry
+                _deleted_entry_list = []
+                async for _item in _res:
+                    _deleted_entry_list.append(_item)
+
+                assert len(_deleted_entry_list) == 1
+                assert _deleted_entry_list[0] == entry
 
     async def test_check_timer(
         self, start_timer: tuple[asyncio.Task[None], asyncio.Event]

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -128,7 +128,7 @@ class TestWithSampleDB:
                 assert _res == 1
         else:
             for entry in entries_to_remove:
-                _res = self.orm_inst.orm_delete_entries(
+                _res = self.orm_inst.orm_delete_entries_with_returning(
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -130,7 +130,7 @@ class TestWithSampleDBAndThreadPool:
                     prim_key_sha256hash=entry.prim_key_sha256hash,
                     _limit=1,
                 )
-                assert isinstance(_res, list)
+                _res_list = list(_res)
 
-                assert len(_res) == 1
-                assert _res[0] == entry
+                assert len(_res_list) == 1
+                assert _res_list[0] == entry

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -124,7 +124,7 @@ class TestWithSampleDBAndThreadPool:
                 assert _res == 1
         else:
             for entry in entries_to_remove:
-                _res = thread_pool.orm_delete_entries(
+                _res = thread_pool.orm_delete_entries_with_returning(
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from concurrent.futures import Future, ThreadPoolExecutor
-from functools import partial
-from typing import Any, Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
 
 import pytest
 
@@ -24,10 +23,6 @@ THREAD_NUM = 2
 WORKER_NUM = 6
 
 
-def _get_result(func: Callable[..., Future[Any]]):
-    return func().result()
-
-
 class TestWithSampleDBAndThreadPool:
     @pytest.fixture(autouse=True, scope="class")
     def thread_pool(self, setup_con_factory: Callable[[], sqlite3.Connection]):
@@ -43,7 +38,7 @@ class TestWithSampleDBAndThreadPool:
 
     def test_create_table(self, thread_pool: SampleDBConnectionPool):
         logger.info("test create table")
-        thread_pool.orm_create_table(without_rowid=True).result()
+        thread_pool.orm_create_table(without_rowid=True)
 
     def test_insert_entries_with_pool(
         self,
@@ -58,7 +53,7 @@ class TestWithSampleDBAndThreadPool:
                 batched(setup_test_data.values(), TEST_INSERT_BATCH_SIZE),
                 start=1,
             ):
-                pool.submit(_get_result, partial(thread_pool.orm_insert_entries, entry))
+                pool.submit(thread_pool.orm_insert_entries, entry)
 
             logger.info(
                 f"all insert tasks are dispatched: {_batch_count} batches with {TEST_INSERT_BATCH_SIZE=}"
@@ -66,7 +61,7 @@ class TestWithSampleDBAndThreadPool:
 
         logger.info("confirm data written")
         for _selected_entry_count, _entry in enumerate(
-            thread_pool.orm_select_entries_gen(), start=1
+            thread_pool.orm_select_entries(), start=1
         ):
             _corresponding_item = setup_test_data[_entry.prim_key]
             assert _corresponding_item == _entry
@@ -78,7 +73,7 @@ class TestWithSampleDBAndThreadPool:
             index_name=INDEX_NAME,
             index_keys=INDEX_KEYS,
             unique=True,
-        ).result()
+        )
 
     def test_orm_execute(
         self,
@@ -90,7 +85,7 @@ class TestWithSampleDBAndThreadPool:
             select_from=thread_pool.orm_table_name,
             function="count",
         )
-        res = thread_pool.orm_execute(sql_stmt).result()
+        res: list[tuple[int]] = thread_pool.orm_execute(sql_stmt)
 
         assert res and res[0][0] == len(setup_test_data)
 
@@ -102,7 +97,7 @@ class TestWithSampleDBAndThreadPool:
             _looked_up = thread_pool.orm_select_entries(
                 key_id=_entry.key_id,
                 prim_key_sha256hash=_entry.prim_key_sha256hash,
-            ).result()
+            )
             _looked_up = list(_looked_up)
             assert len(_looked_up) == 1
             assert _looked_up[0] == _entry
@@ -125,7 +120,7 @@ class TestWithSampleDBAndThreadPool:
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
                     _limit=1,
-                ).result()
+                )
                 assert _res == 1
         else:
             for entry in entries_to_remove:
@@ -134,7 +129,7 @@ class TestWithSampleDBAndThreadPool:
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
                     _limit=1,
-                ).result()
+                )
                 assert isinstance(_res, list)
 
                 assert len(_res) == 1


### PR DESCRIPTION
## Introduction

This PR fully re-implements the orm_threadpool and orm_async implementation, simplifies and reduce boilerplate code by implementing generic wrapping helpers for wrapping single-thread APIs from ORMBase within thread context.
Two types of wrapping helpers are implemented, one is for APIs returing value, another one is for APIs returning generator.

Also, considering the typing complexity, this PR splits the ORMBase.orm_delete_entries into two new methods:
1. the normal version of orm_delete_entries which returns deleted row count.
2. orm_delete_entries_with_returning, which enables returning stmt on DELETE.

With the help of the new mechanism introduced by this PR, now all APIs from ORMBase(except for orm_con) are supported in orm_threadpool and orm_async.

BREAKING: now ORMThreadPool and AsyncORMThreadPool are NOT subclass of ORMBase anymore, they are standalone separated types.

BREAKING: for users previously using ORMBase.orm_delete_entries with returning stmt, now they should switch to use ORMBase.orm_delete_entries_with_returning.

