### PR TITLE
feat: orm: allow pre-define and pin table_name when defining ORM

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -103,7 +103,6 @@ class ORMBase(Generic[TableSpecType]):
             raise ValueError(
                 "table_name must be either set by <table_name> init param, or by defining <_orm_table_name> attr."
             )
-
         self._schema_name = schema_name
         self._con = con
         row_factory_setter(con, self.orm_table_spec, row_factory)

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -86,8 +86,8 @@ class ORMBase(Generic[TableSpecType]):
     """
 
     orm_table_spec: type[TableSpecType]
-    _orm_table_name: str | None = None
-    """Pre-defined table_name for the ORM. This is for pinning table_name when creating ORM object."""
+    _orm_table_name: str
+    """table_name for the ORM. This can be used for pinning table_name when creating ORM object."""
 
     def __init__(
         self,
@@ -97,12 +97,12 @@ class ORMBase(Generic[TableSpecType]):
         *,
         row_factory: RowFactorySpecifier = "table_spec",
     ) -> None:
-        _table_name = table_name or self._orm_table_name
-        if not _table_name:
+        if table_name:
+            self._orm_table_name = table_name
+        if getattr(self, "_orm_table_name", None) is None:
             raise ValueError(
                 "table_name must be either set by <table_name> init param, or by defining <_orm_table_name> attr."
             )
-        self._table_name = _table_name
 
         self._schema_name = schema_name
         self._con = con
@@ -142,9 +142,9 @@ class ORMBase(Generic[TableSpecType]):
             return "<schema_name>.<table_name>", otherwise return <table_name>.
         """
         return (
-            f"{self._schema_name}.{self._table_name}"
+            f"{self._schema_name}.{self._orm_table_name}"
             if self._schema_name
-            else self._table_name
+            else self._orm_table_name
         )
 
     def orm_execute(

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -25,6 +25,8 @@ TIMER_INTERVAL = 0.1
 class SampleDBAsyncio(AsyncORMBase[SampleTable]):
     """Test connection pool with async API."""
 
+    _orm_table_name = TABLE_NAME
+
 
 @pytest.mark.asyncio(loop_scope="class")
 class TestWithSampleDBWithAsyncIO:
@@ -35,7 +37,6 @@ class TestWithSampleDBWithAsyncIO:
     ):
         try:
             pool = SampleDBAsyncio(
-                TABLE_NAME,
                 con_factory=setup_con_factory,
                 number_of_cons=THREAD_NUM,
             )

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 class SampleDBConnectionPool(ORMThreadPoolBase[SampleTable]):
     """Test connection pool."""
 
+    _orm_table_name = TABLE_NAME
+
 
 THREAD_NUM = 2
 WORKER_NUM = 6
@@ -28,7 +30,6 @@ class TestWithSampleDBAndThreadPool:
     def thread_pool(self, setup_con_factory: Callable[[], sqlite3.Connection]):
         try:
             pool = SampleDBConnectionPool(
-                TABLE_NAME,
                 con_factory=setup_con_factory,
                 number_of_cons=THREAD_NUM,
             )


### PR DESCRIPTION
This PR introduces to expose the `_orm_table_name` attr as an API for the ORM.
User can use this attr to pre-define and pin table_name in advance. 
The previous init param `table_name` is still in-use, and will override the pre-defined `_orm_table_name` if specified.