### PR TITLE
refactor: orm: implement and use a general parameterized_class_getitem in _orm._utils module

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -137,7 +137,8 @@ class AsyncORMBase(Generic[TableSpecType]):
 
         self._loop = asyncio.get_running_loop()
 
-    __class_getitem__ = classmethod(parameterized_class_getitem)
+    def __class_getitem__(cls, params):
+        return parameterized_class_getitem(cls, params)
 
     @cached_property
     def orm_table_name(self) -> str:

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -106,7 +106,8 @@ class ORMBase(Generic[TableSpecType]):
             self._con = con()
         row_factory_setter(self._con, self.orm_table_spec, row_factory)
 
-    __class_method__ = classmethod(parameterized_class_getitem)
+    def __class_getitem__(cls, params):
+        return parameterized_class_getitem(cls, params)
 
     @property
     def orm_con(self) -> sqlite3.Connection:

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -12,19 +12,13 @@ from typing import (
     TypeVar,
     Union,
 )
-from weakref import WeakValueDictionary
 
 from typing_extensions import ParamSpec
 
+from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
 from simple_sqlite3_orm._sqlite_spec import INSERT_OR, ORDER_DIRECTION
 from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType
 from simple_sqlite3_orm._types import ConnectionFactoryType, RowFactoryType
-from simple_sqlite3_orm._utils import GenericAlias
-
-_parameterized_orm_cache: WeakValueDictionary[
-    tuple[type[ORMBase], type[TableSpec]], type[ORMBase[Any]]
-] = WeakValueDictionary()
-
 
 P = ParamSpec("P")
 RT = TypeVar("RT")
@@ -112,23 +106,7 @@ class ORMBase(Generic[TableSpecType]):
             self._con = con()
         row_factory_setter(self._con, self.orm_table_spec, row_factory)
 
-    def __class_getitem__(cls, params: Any | type[Any] | type[TableSpecType]) -> Any:
-        # just for convienience, passthrough anything that is not type[TableSpecType]
-        #   to Generic's __class_getitem__ and return it.
-        # Typically this is for subscript ORMBase with TypeVar or another Generic.
-        if not (isinstance(params, type) and issubclass(params, TableSpec)):
-            return super().__class_getitem__(params)  # type: ignore
-
-        key = (cls, params)
-        if _cached_type := _parameterized_orm_cache.get(key):
-            return GenericAlias(_cached_type, params)
-
-        new_parameterized_ormbase: type[ORMBase] = type(
-            f"{cls.__name__}[{params.__name__}]", (cls,), {}
-        )
-        new_parameterized_ormbase.orm_table_spec = params  # type: ignore
-        _parameterized_orm_cache[key] = new_parameterized_ormbase
-        return GenericAlias(new_parameterized_ormbase, params)
+    __class_method__ = classmethod(parameterized_class_getitem)
 
     @property
     def orm_con(self) -> sqlite3.Connection:

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -129,7 +129,8 @@ class ORMThreadPoolBase(Generic[TableSpecType]):
             thread_name_prefix=thread_name_prefix,
         )
 
-    __class_method__ = classmethod(parameterized_class_getitem)
+    def __class_getitem__(cls, params):
+        return parameterized_class_getitem(cls, params)
 
     def _thread_initializer(self, con_factory, row_factory) -> None:
         """Prepare thread_scope ORMBase instance for this worker thread."""

--- a/src/simple_sqlite3_orm/_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_orm/_utils.py
@@ -14,7 +14,7 @@ _parameterized_orm_cache: WeakValueDictionary[
 def parameterized_class_getitem(
     cls, params: Any | type[Any] | type[TableSpecType] | tuple[type[Any], ...]
 ) -> Any:
-    if isinstance(params, tuple) or not isinstance(params, type):
+    if not isinstance(params, type):
         raise TypeError(
             f"{cls.__name__} only allows to be parameterized with exactly one type, but get {params=}"
         )

--- a/src/simple_sqlite3_orm/_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_orm/_utils.py
@@ -12,7 +12,9 @@ _parameterized_orm_cache: WeakValueDictionary[
 ] = WeakValueDictionary()
 
 
-def class_getitem(cls, params: Any | type[Any] | type[TableSpecType]) -> Any:
+def parameterized_class_getitem(
+    cls, params: Any | type[Any] | type[TableSpecType]
+) -> Any:
     # just for convienience, passthrough anything that is not type[TableSpecType]
     #   to Generic's __class_getitem__ and return it.
     # Typically this is for subscript ORMBase with TypeVar or another Generic.

--- a/src/simple_sqlite3_orm/_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_orm/_utils.py
@@ -12,21 +12,29 @@ _parameterized_orm_cache: WeakValueDictionary[
 
 
 def parameterized_class_getitem(
-    cls, params: Any | type[Any] | type[TableSpecType]
+    cls, params: Any | type[Any] | type[TableSpecType] | tuple[type[Any], ...]
 ) -> Any:
-    # just for convienience, passthrough anything that is not type[TableSpecType]
-    #   to Generic's __class_getitem__ and return it.
-    # Typically this is for subscript ORMBase with TypeVar or another Generic.
-    if not (isinstance(params, type) and issubclass(params, TableSpec)):
-        return super(cls).__class_getitem__(params)
+    if isinstance(params, tuple) or not isinstance(params, type):
+        raise TypeError(
+            f"{cls.__name__} only allows to be parameterized with exactly one type, but get {params=}"
+        )
 
     key = (cls, params)
     if _cached_type := _parameterized_orm_cache.get(key):
         return GenericAlias(_cached_type, params)
 
-    new_parameterized_ormbase: type[Any] = type(
-        f"{cls.__name__}[{params.__name__}]", (cls,), {}
-    )
-    new_parameterized_ormbase.orm_table_spec = params
-    _parameterized_orm_cache[key] = new_parameterized_ormbase
-    return GenericAlias(new_parameterized_ormbase, params)
+    # make a new type from the param
+    if issubclass(params, TableSpec):
+        new_parameterized_ormbase: type[Any] = type(
+            f"{cls.__name__}[{params.__name__}]", (cls,), {}
+        )
+        new_parameterized_ormbase.orm_table_spec = params
+        _parameterized_orm_cache[key] = new_parameterized_ormbase
+        return GenericAlias(new_parameterized_ormbase, params)
+
+    # just for convienience, for anything that is not type[TableSpecType],
+    #   wrap it with GenericAlias.
+    # actually we should only accept TypeVars or Generic, but that is not a very big problem,
+    #   so just leave the current implementation as it.
+    # typically this is for typing purpose.
+    return GenericAlias(cls, params)

--- a/src/simple_sqlite3_orm/_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_orm/_utils.py
@@ -7,8 +7,7 @@ from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType
 from simple_sqlite3_orm._utils import GenericAlias
 
 _parameterized_orm_cache: WeakValueDictionary[
-    tuple[type[Any], type[TableSpec]],
-    type[Any[TableSpec]],
+    tuple[type[Any], type[TableSpec]], type[Any[TableSpec]]
 ] = WeakValueDictionary()
 
 

--- a/src/simple_sqlite3_orm/_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_orm/_utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+from weakref import WeakValueDictionary
+
+from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType
+from simple_sqlite3_orm._utils import GenericAlias
+
+_parameterized_orm_cache: WeakValueDictionary[
+    tuple[type[Any], type[TableSpec]],
+    type[Any[TableSpec]],
+] = WeakValueDictionary()
+
+
+def class_getitem(cls, params: Any | type[Any] | type[TableSpecType]) -> Any:
+    # just for convienience, passthrough anything that is not type[TableSpecType]
+    #   to Generic's __class_getitem__ and return it.
+    # Typically this is for subscript ORMBase with TypeVar or another Generic.
+    if not (isinstance(params, type) and issubclass(params, TableSpec)):
+        return super(cls).__class_getitem__(params)
+
+    key = (cls, params)
+    if _cached_type := _parameterized_orm_cache.get(key):
+        return GenericAlias(_cached_type, params)
+
+    new_parameterized_ormbase: type[Any] = type(
+        f"{cls.__name__}[{params.__name__}]", (cls,), {}
+    )
+    new_parameterized_ormbase.orm_table_spec = params
+    _parameterized_orm_cache[key] = new_parameterized_ormbase
+    return GenericAlias(new_parameterized_ormbase, params)

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -35,7 +35,7 @@ else:
 
 
 if sys.version_info >= (3, 9):
-    from types import GenericAlias
+    from types import GenericAlias  # noqa: F401
 else:
     from typing import List
 


### PR DESCRIPTION
## Introduction

This PR introduces a general parameterized_class_getitem implementation, so that each ORM base type doesn't need to define their own class_getitem implementation(which all are the same). 

Note that class_getitem MUST define with def statement within class namespace during class definition. A plain variable assignement within the class namespace will not work. How the class_getitem is defined during class creation is implemented deep in the cpython:
```
# won't work
class ORMBase:
    __class_getitem__ = parameterized_class_getitem

# this will work
class ORMBase:
    def __class_getitem__(cls, params):
        return parameterized_class_getitem(cls, params)
```

Other changes:
1. parameterized_class_getitiem: fix handling parameterized with non TableSpec type. 