### PR TITLE
feat: table_spec: now TypeAffinityRepr can be automatically calculated from field type, no need to explicitly set TypeAffinityRepr 

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -106,13 +106,15 @@ class TableSpec(BaseModel):
             ValueError on col doesn't exist or invalid col definition.
         """
         datatype_name, constrain = "", ""
-        for metadata in cls.table_get_col_fieldinfo(column_name).metadata:
+        column_meta = cls.table_get_col_fieldinfo(column_name)
+
+        for metadata in column_meta.metadata:
             if isinstance(metadata, TypeAffinityRepr):
                 datatype_name = metadata
             elif isinstance(metadata, ConstrainRepr):
                 constrain = metadata
         if not datatype_name:
-            raise ValueError("data affinity must be set")
+            datatype_name = TypeAffinityRepr(column_meta.annotation)
 
         res = f"{column_name} {datatype_name} {constrain}".strip()
         return res

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -77,7 +77,9 @@ class TypeAffinityRepr(str):
             and _args[-1] is type(None)
         ):
             # Optional[X] is actually Union[X, type(None)]
-            return cls._map_from_type(_args[0])
+            # after extract the actual types from Optional,
+            #   do mapping from the beginning.
+            return cls.__new__(cls, _args[0])
         if _origin is not None:
             raise TypeError(f"not one of Literal or Optional: {_in}")
 

--- a/src/simple_sqlite3_orm/utils.py
+++ b/src/simple_sqlite3_orm/utils.py
@@ -322,7 +322,7 @@ def wrap_value(value: Any) -> str:
         return f"{value}"
     if isinstance(value, str):
         if isinstance(value, Enum):
-            return f"{value.value}"
+            return rf'"{value.value}"'
         return rf'"{value}"'
     if isinstance(value, bytes):
         return rf"x'{value.hex()}'"

--- a/src/simple_sqlite3_orm/utils.py
+++ b/src/simple_sqlite3_orm/utils.py
@@ -317,8 +317,12 @@ def wrap_value(value: Any) -> str:
     For bytes, the value will be converted as x'<bytes_in_hex>'.
     """
     if isinstance(value, (int, float)):
+        if isinstance(value, Enum):
+            return f"{value.value}"
         return f"{value}"
     if isinstance(value, str):
+        if isinstance(value, Enum):
+            return f"{value.value}"
         return rf'"{value}"'
     if isinstance(value, bytes):
         return rf"x'{value.hex()}'"

--- a/src/simple_sqlite3_orm/utils.py
+++ b/src/simple_sqlite3_orm/utils.py
@@ -316,13 +316,15 @@ def wrap_value(value: Any) -> str:
     For str, the value will be wrapped with parenthesis.
     For bytes, the value will be converted as x'<bytes_in_hex>'.
     """
+    # NOTE: handle Enum with data type first
+    if isinstance(value, int) and isinstance(value, Enum):
+        return f"{value.value}"
+    if isinstance(value, str) and isinstance(value, Enum):
+        return rf'"{value.value}"'
+
     if isinstance(value, (int, float)):
-        if isinstance(value, Enum):
-            return f"{value.value}"
         return f"{value}"
     if isinstance(value, str):
-        if isinstance(value, Enum):
-            return rf'"{value.value}"'
         return rf'"{value}"'
     if isinstance(value, bytes):
         return rf"x'{value.hex()}'"

--- a/tests/sample_db/table.py
+++ b/tests/sample_db/table.py
@@ -39,8 +39,7 @@ class SampleTable(TableSpec):
 
     # ------ enums ------ #
     choice_abc: Annotated[
-        ChoiceABC,
-        TypeAffinityRepr(ChoiceABC),
+        "ChoiceABC",
         ConstrainRepr(
             "NOT NULL",
             (
@@ -53,8 +52,7 @@ class SampleTable(TableSpec):
         ),
     ] = ChoiceABC.A
     optional_choice_123: Annotated[
-        Optional[Choice123],
-        TypeAffinityRepr(Choice123),
+        "Optional[Choice123]",
         ConstrainRepr(
             (
                 "CHECK",
@@ -71,8 +69,7 @@ class SampleTable(TableSpec):
 
     # ------ literals ------ #
     optional_num_literal: Annotated[
-        Optional[SomeIntLiteral],
-        TypeAffinityRepr(SomeIntLiteral),
+        Optional["SomeIntLiteral"],
         ConstrainRepr(
             (
                 "CHECK",
@@ -89,7 +86,6 @@ class SampleTable(TableSpec):
     ] = None
     str_literal: Annotated[
         SomeStrLiteral,
-        TypeAffinityRepr(SomeStrLiteral),
         ConstrainRepr(
             "NOT NULL",
             (
@@ -111,7 +107,6 @@ class SampleTable(TableSpec):
     #   derived by prim_key, check MyStr's methods for mor details.
     prim_key: Annotated[
         Mystr,
-        TypeAffinityRepr(Mystr),
         ConstrainRepr(
             "PRIMARY KEY",
             (
@@ -123,13 +118,16 @@ class SampleTable(TableSpec):
     ]
     prim_key_sha256hash: Annotated[
         bytes,
-        TypeAffinityRepr(bytes),
         ConstrainRepr("NOT NULL", "UNIQUE"),
         SkipValidation,
     ]
     prim_key_magicf: Annotated[
-        float, TypeAffinityRepr(float), ConstrainRepr("NOT NULL"), SkipValidation
+        float,
+        ConstrainRepr("NOT NULL"),
+        SkipValidation,
     ]
     prim_key_bln: Annotated[
-        bool, TypeAffinityRepr(bool), ConstrainRepr("NOT NULL"), SkipValidation
+        bool,
+        ConstrainRepr("NOT NULL"),
+        SkipValidation,
     ]

--- a/tests/sample_db/table.py
+++ b/tests/sample_db/table.py
@@ -39,7 +39,7 @@ class SampleTable(TableSpec):
 
     # ------ enums ------ #
     choice_abc: Annotated[
-        "ChoiceABC",
+        ChoiceABC,
         ConstrainRepr(
             "NOT NULL",
             (
@@ -52,7 +52,7 @@ class SampleTable(TableSpec):
         ),
     ] = ChoiceABC.A
     optional_choice_123: Annotated[
-        "Optional[Choice123]",
+        Optional[Choice123],
         ConstrainRepr(
             (
                 "CHECK",
@@ -69,7 +69,7 @@ class SampleTable(TableSpec):
 
     # ------ literals ------ #
     optional_num_literal: Annotated[
-        Optional["SomeIntLiteral"],
+        Optional[SomeIntLiteral],
         ConstrainRepr(
             (
                 "CHECK",
@@ -121,13 +121,5 @@ class SampleTable(TableSpec):
         ConstrainRepr("NOT NULL", "UNIQUE"),
         SkipValidation,
     ]
-    prim_key_magicf: Annotated[
-        float,
-        ConstrainRepr("NOT NULL"),
-        SkipValidation,
-    ]
-    prim_key_bln: Annotated[
-        bool,
-        ConstrainRepr("NOT NULL"),
-        SkipValidation,
-    ]
+    prim_key_magicf: float
+    prim_key_bln: bool

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -6,26 +6,21 @@ from typing import Any, Iterable, Optional
 import pytest
 from typing_extensions import Annotated
 
-from simple_sqlite3_orm import ConstrainRepr, TableSpec, TypeAffinityRepr
+from simple_sqlite3_orm import ConstrainRepr, TableSpec
 
 
 class SimpleTableForTest(TableSpec):
     id: Annotated[
         int,
-        TypeAffinityRepr(int),
         ConstrainRepr("PRIMARY KEY"),
     ]
 
     id_str: Annotated[
         str,
-        TypeAffinityRepr(str),
         ConstrainRepr("NOT NULL"),
     ]
 
-    extra: Annotated[
-        Optional[float],
-        TypeAffinityRepr(float),
-    ] = None
+    extra: Optional[float] = None
 
 
 @pytest.mark.parametrize(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -22,6 +22,10 @@ from tests.sample_db._types import Choice123, ChoiceABC, SomeIntLiteral, SomeStr
         (SomeIntLiteral, SQLiteTypeAffinity.INTEGER),
         (SomeStrLiteral, SQLiteTypeAffinity.TEXT),
         (Optional[bytes], SQLiteTypeAffinity.BLOB),
+        (Optional[Choice123], SQLiteTypeAffinity.INTEGER),
+        (Optional[ChoiceABC], SQLiteTypeAffinity.TEXT),
+        (Optional[SomeIntLiteral], SQLiteTypeAffinity.INTEGER),
+        (Optional[SomeStrLiteral], SQLiteTypeAffinity.TEXT),
     ),
 )
 def test_typeafinityrepr(_in, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,7 +144,7 @@ def test_concatenate_condition(stmts, with_parenthese, expected):
         ("a_string", r'"a_string"'),
         (None, r"NULL"),
         (bytes.fromhex("1234567890AABBCC"), r"x'1234567890aabbcc'"),
-        (Choice123.ONE, 1),
+        (Choice123.ONE, r"1"),
         (ChoiceABC.A, r'"A"'),
     ),
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,6 +144,8 @@ def test_concatenate_condition(stmts, with_parenthese, expected):
         ("a_string", r'"a_string"'),
         (None, r"NULL"),
         (bytes.fromhex("1234567890AABBCC"), r"x'1234567890aabbcc'"),
+        (Choice123.ONE, 1),
+        (ChoiceABC.A, r'"A"'),
     ),
 )
 def test_wrap_value(value, expected):


### PR DESCRIPTION
## Introduction

This PR introduces the feature of automatically calculating the type affinity from field type if possible. Field type of sqlite3 natively supported types, IntEnum, StrEnum or Literals are supported.

NOTE that ForwardRef is still not fully supported (something wrong might happen in py3.8).

Other changes:
1. wrap_value: fix handling enum type.
2. TypeAffinityRepr: fix handling Optional type when type args within the Optional is not real type.
3. tests.sample_table: now SampleTable does't explicitly set TypeAffinityRepr for fields with sqlite3 natively supported types.
