### PR TITLE
refactor: re-implement ConstrainRepr, not subclass str anymore

### DIFF
--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -160,17 +160,17 @@ class ConstrainRepr:
         )
 
     Attrs:
-        contrains (set[str | tuple[str, str]]): a set of constrains.
+        constrains (set[str | tuple[str, str]]): a set of constrains.
     """
 
     def __init__(
         self, *params: ConstrainLiteral | tuple[ConstrainLiteral, str] | Any
     ) -> None:
-        self.contrains = tuple(params)
+        self.constrains = tuple(params)
 
     def __str__(self) -> str:
         with StringIO() as _buffer:
-            for arg in self.contrains:
+            for arg in self.constrains:
                 if isinstance(arg, tuple):
                     _buffer.write(" ".join(arg))
                 else:
@@ -182,10 +182,10 @@ class ConstrainRepr:
         return f'<{self.__class__.__qualname__}: "{self}">'
 
     def __eq__(self, other: Any) -> bool:  # pragma: no cover
-        return isinstance(other, self.__class__) and other.contrains == self.contrains
+        return isinstance(other, self.__class__) and other.constrains == self.constrains
 
     def __hash__(self) -> int:  # pragma: no cover
-        return hash(self.contrains)
+        return hash(self.constrains)
 
 
 def gen_sql_stmt(*components: str) -> str:

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -134,7 +134,7 @@ class TypeAffinityRepr:
         return self.type_affinity
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<{self.__qualname__}: {self}>"
+        return f'<{self.__class__.__qualname__}: "{self}">'
 
     def __eq__(self, other: object) -> bool:  # pragma: no cover
         return (
@@ -179,7 +179,7 @@ class ConstrainRepr:
             return _buffer.getvalue().strip()
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<{self.__qualname__}: {self} >"
+        return f'<{self.__class__.__qualname__}: "{self}">'
 
     def __eq__(self, other: Any) -> bool:  # pragma: no cover
         return isinstance(other, self.__class__) and other.contrains == self.contrains

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -166,7 +166,7 @@ class ConstrainRepr:
     def __init__(
         self, *params: ConstrainLiteral | tuple[ConstrainLiteral, str] | Any
     ) -> None:
-        self.contrains = frozenset(params)
+        self.contrains = tuple(params)
 
     def __str__(self) -> str:
         with StringIO() as _buffer:

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -160,17 +160,17 @@ class ConstrainRepr:
         )
 
     Attrs:
-        constrains (set[str | tuple[str, str]]): a set of constrains.
+        constraints (set[str | tuple[str, str]]): a set of constrains.
     """
 
     def __init__(
         self, *params: ConstrainLiteral | tuple[ConstrainLiteral, str] | Any
     ) -> None:
-        self.constrains = tuple(params)
+        self.constraints = tuple(params)
 
     def __str__(self) -> str:
         with StringIO() as _buffer:
-            for arg in self.constrains:
+            for arg in self.constraints:
                 if isinstance(arg, tuple):
                     _buffer.write(" ".join(arg))
                 else:
@@ -182,10 +182,12 @@ class ConstrainRepr:
         return f'<{self.__class__.__qualname__}: "{self}">'
 
     def __eq__(self, other: Any) -> bool:  # pragma: no cover
-        return isinstance(other, self.__class__) and other.constrains == self.constrains
+        return (
+            isinstance(other, self.__class__) and other.constraints == self.constraints
+        )
 
     def __hash__(self) -> int:  # pragma: no cover
-        return hash(self.constrains)
+        return hash(self.constraints)
 
 
 def gen_sql_stmt(*components: str) -> str:

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -48,4 +48,4 @@ def test_typeafinityrepr(_in, expected):
     ),
 )
 def test_constrainrepr(_in, expected):
-    assert ConstrainRepr(_in) == expected
+    assert f"{_in}" == expected


### PR DESCRIPTION
## Introduction

This PR re-implements the ConstrainRepr, now it doesn't subclass str anymore, and it exposes `constraints` tuple attr.
The behavior of ConstrainRepr aligns with the previous implementation, which its `__str__` still returns constrains in one string.

Other fix:
1. fix TypeAffinityRepr's `__repr__`: `__qualname__` only defined on the class, not on object.