### PR TITLE
tests(e2e): do not use limit on delete test as SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile flag is not enabled by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
 build-backend = "hatchling.build"
 
-requires = ["hatch-vcs", "hatchling>=1.20"]
+requires = [ "hatch-vcs", "hatchling>=1.20" ]
 
 [project]
 name = "simple-sqlite3-orm"
 description = "A simple yet powerful SQLite3 ORM, powered by pydantic."
 readme = "README.md"
 license = { file = "LICENSE" }
-authors = [{ name = "pga2rn", email = "aaronpigybd@gmail.com" }]
+authors = [ { name = "pga2rn", email = "aaronpigybd@gmail.com" } ]
 requires-python = ">=3.8"
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
@@ -21,8 +21,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = ["version"]
-dependencies = ["pydantic>=2.6,<3", "typing-extensions>=4"]
+dynamic = [ "version" ]
+dependencies = [ "pydantic>=2.6,<3", "typing-extensions>=4" ]
 optional-dependencies.dev = [
   "coverage>=7.6,<7.7",
   "pytest>=8.3,<8.4",
@@ -41,14 +41,14 @@ log_auto_indent = true
 log_format = "%(asctime)s %(levelname)s %(filename)s %(funcName)s,%(lineno)d %(message)s"
 log_cli = true
 log_cli_level = "INFO"
-pythonpath = ["src"]
-testpaths = ["./tests"]
+pythonpath = [ "src" ]
+testpaths = [ "./tests" ]
 
 [tool.coverage.run]
-omit = ["_version.py"]
+omit = [ "_version.py" ]
 branch = false
 relative_files = true
-source = ["simple_sqlite3_orm"]
+source = [ "simple_sqlite3_orm" ]
 
 [tool.coverage.report]
 exclude_also = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,18 @@
 [build-system]
 build-backend = "hatchling.build"
 
-requires = [ "hatch-vcs", "hatchling>=1.20" ]
+requires = ["hatch-vcs", "hatchling>=1.20"]
 
 [project]
 name = "simple-sqlite3-orm"
 description = "A simple yet powerful SQLite3 ORM, powered by pydantic."
 readme = "README.md"
 license = { file = "LICENSE" }
-authors = [ { name = "pga2rn", email = "aaronpigybd@gmail.com" } ]
+authors = [{ name = "pga2rn", email = "aaronpigybd@gmail.com" }]
 requires-python = ">=3.8"
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
-  "Operating System :: Microsoft :: Windows",
-  "Operating System :: Unix",
+  "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
@@ -22,8 +21,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [ "version" ]
-dependencies = [ "pydantic>=2.6,<3", "typing-extensions>=4" ]
+dynamic = ["version"]
+dependencies = ["pydantic>=2.6,<3", "typing-extensions>=4"]
 optional-dependencies.dev = [
   "coverage>=7.6,<7.7",
   "pytest>=8.3,<8.4",
@@ -42,14 +41,14 @@ log_auto_indent = true
 log_format = "%(asctime)s %(levelname)s %(filename)s %(funcName)s,%(lineno)d %(message)s"
 log_cli = true
 log_cli_level = "INFO"
-pythonpath = [ "src" ]
-testpaths = [ "./tests" ]
+pythonpath = ["src"]
+testpaths = ["./tests"]
 
 [tool.coverage.run]
-omit = [ "_version.py" ]
+omit = ["_version.py"]
 branch = false
 relative_files = true
-source = [ "simple_sqlite3_orm" ]
+source = ["simple_sqlite3_orm"]
 
 [tool.coverage.report]
 exclude_also = [

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -147,7 +147,7 @@ class TestWithSampleDBWithAsyncIO:
                 _res = await async_pool.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # _limit=1,
                 )
                 assert _res == 1
         else:
@@ -156,7 +156,7 @@ class TestWithSampleDBWithAsyncIO:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # _limit=1,
                 )
 
                 _deleted_entry_list = []

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -123,7 +123,9 @@ class TestWithSampleDB:
                 _res = self.orm_inst.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # NOTE(20241230): limit on update/delete requires compile flag SQLITE_ENABLE_UPDATE_DELETE_LIMIT enabled,
+                    #   which is not set to be enabled by default. See https://www.sqlite.org/compile.html for more details.
+                    # _limit=1,
                 )
                 assert _res == 1
         else:
@@ -132,7 +134,7 @@ class TestWithSampleDB:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # _limit=1,
                 )
                 assert isinstance(_res, Generator)
 

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -120,7 +120,7 @@ class TestWithSampleDBAndThreadPool:
                 _res = thread_pool.orm_delete_entries(
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # _limit=1,
                 )
                 assert _res == 1
         else:
@@ -129,7 +129,7 @@ class TestWithSampleDBAndThreadPool:
                     _returning_cols="*",
                     key_id=entry.key_id,
                     prim_key_sha256hash=entry.prim_key_sha256hash,
-                    _limit=1,
+                    # _limit=1,
                 )
                 _res_list = list(_res)
 


### PR DESCRIPTION
This fixes tests on windows as seems like SQLITE_ENABLE_UPDATE_DELETE_LIMIT is not enabled(not enabled by default, see https://www.sqlite.org/compile.html) on sqlite3 libs with python distribution on windows.

Other changes: now set as OS Independent in pyproject.toml.