### PR TITLE
feat: table_spec: add table_row_factory2 API

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -199,7 +199,11 @@ class TableSpec(BaseModel):
 
     @classmethod
     def table_row_factory(
-        cls, _cursor: sqlite3.Cursor, _row: tuple[Any, ...], *, validation: bool = True
+        cls,
+        _cursor: sqlite3.Cursor,
+        _row: tuple[Any, ...] | Any,
+        *,
+        validation: bool = True,
     ) -> Self | tuple[Any, ...]:
         """A general row_factory implement for used in sqlite3 connection.
 
@@ -232,7 +236,7 @@ class TableSpec(BaseModel):
     def table_row_factory2(
         cls,
         _cursor: sqlite3.Cursor,
-        _row: tuple[Any, ...],
+        _row: tuple[Any, ...] | Any,
         *,
         validation: bool = True,
     ) -> Self:

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Mapping
 from typing import Any, Iterable, Optional
 
@@ -21,6 +22,48 @@ class SimpleTableForTest(TableSpec):
     ]
 
     extra: Optional[float] = None
+
+
+TBL_NAME = "test_table"
+
+
+class TestTableSpecWithDB:
+    """A quick and simple test to test through normal usage of tablespec"""
+
+    ENTRY_FOR_TEST = SimpleTableForTest(id=123, id_str="123", extra=0.123)
+
+    @pytest.fixture(scope="class")
+    def db_conn(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def test_table_create(self, db_conn: sqlite3.Connection):
+        table_create_stmt = SimpleTableForTest.table_create_stmt(table_name=TBL_NAME)
+        with db_conn as _conn:
+            _conn.execute(table_create_stmt)
+
+    def test_insert_entry(self, db_conn: sqlite3.Connection):
+        _to_insert = self.ENTRY_FOR_TEST
+        table_insert_stmt = SimpleTableForTest.table_insert_stmt(insert_into=TBL_NAME)
+        with db_conn as _conn:
+            _conn.execute(table_insert_stmt, _to_insert.table_dump_asdict())
+
+    def test_lookup_entry(self, db_conn: sqlite3.Connection):
+        _to_lookup = self.ENTRY_FOR_TEST
+        table_select_stmt = SimpleTableForTest.table_select_stmt(
+            select_from=TBL_NAME, select_cols="rowid, *", where_cols=("id",)
+        )
+        with db_conn as _conn:
+            _cur = _conn.execute(table_select_stmt, {"id": _to_lookup.id})
+            _cur.row_factory = SimpleTableForTest.table_row_factory2
+
+            res = _cur.fetchall()
+            assert len(res) == 1
+            assert isinstance(res[0], SimpleTableForTest)
+            assert res[0] == _to_lookup
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Introduction

This PR introduces the new `table_row_factory2` API. 
Unlike the general purpose `table_row_factory` that expecs the input row has exactly the same schema as tablespec, otherwise returns the raw input row, the `table_row_factory2` API allows input row contains unknown or extra cols(like `rowid`), and only picks known col/value pairs to instanitiate the tablespec. Also lack of uncritical cols is also allowed.