### PR TITLE
refactor: orm: re-implement orm_select_all_with_pagination API

### DIFF
--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -101,7 +101,7 @@ class TestWithSampleDB:
             ),
             start=1,
         ):
-            assert _entry.prim_key in setup_test_data
+            assert setup_test_data[_entry.prim_key] == _entry
         assert _cnt == len(setup_test_data)
 
     def test_delete_entries(


### PR DESCRIPTION
## Introduction

This PR reimplements the orm_select_all_with_pagination API to achieve:
1. support table with holes, ensuring all rows are collected.
2. slightly improve performance by using table_row_factory2.