### PR TITLE
feat: ORM: taking dict for specifying cols or col/value pairs, improve typing with ColsDefinition and ColsDefinitionWithDirection type alias

### DIFF
--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -15,10 +15,14 @@ from simple_sqlite3_orm._sqlite_spec import (
 )
 from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType, gen_sql_stmt
 from simple_sqlite3_orm._types import (
-    ConnectionFactoryType,
     DatetimeISO8601,
     DatetimeUnixTimestamp,
     DatetimeUnixTimestampInt,
+)
+from simple_sqlite3_orm._typing import (
+    ColsDefinition,
+    ColsDefinitionWithDirection,
+    ConnectionFactoryType,
     RowFactoryType,
 )
 from simple_sqlite3_orm._utils import ConstrainRepr, TypeAffinityRepr
@@ -52,4 +56,6 @@ __all__ = [
     "__version__",
     "__version_tuple__",
     "version",
+    "ColsDefinition",
+    "ColsDefinitionWithDirection",
 ]

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -13,7 +13,7 @@ from simple_sqlite3_orm._orm._base import RowFactorySpecifier
 from simple_sqlite3_orm._orm._multi_thread import ORMBase, ORMThreadPoolBase
 from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
 from simple_sqlite3_orm._table_spec import TableSpecType
-from simple_sqlite3_orm._types import ConnectionFactoryType
+from simple_sqlite3_orm._typing import ConnectionFactoryType
 
 logger = logging.getLogger(__name__)
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -248,7 +248,7 @@ class ORMBase(Generic[TableSpecType]):
             index_name=index_name,
             unique=unique,
             if_not_exists=allow_existed,
-            index_cols=index_keys,
+            index_cols=tuple(index_keys),
         )
         with self._con as con:
             con.execute(index_create_stmt)
@@ -286,12 +286,16 @@ class ORMBase(Generic[TableSpecType]):
             _col_values_dict = {}
         _col_values_dict.update(col_values)
 
+        _parsed_order_by = None
+        if _order_by:
+            _parsed_order_by = tuple(_order_by)
+
         table_select_stmt = self.orm_table_spec.table_select_stmt(
             select_from=self.orm_table_name,
             distinct=_distinct,
-            order_by=_order_by,
+            order_by=_parsed_order_by,
             limit=_limit,
-            where_cols=_col_values_dict,
+            where_cols=tuple(_col_values_dict),
         )
 
         with self._con as con:
@@ -334,12 +338,16 @@ class ORMBase(Generic[TableSpecType]):
             _col_values_dict = {}
         _col_values_dict.update(col_values)
 
+        _parsed_order_by = None
+        if _order_by:
+            _parsed_order_by = tuple(_order_by)
+
         table_select_stmt = self.orm_table_spec.table_select_stmt(
             select_from=self.orm_table_name,
             distinct=_distinct,
-            order_by=_order_by,
+            order_by=_parsed_order_by,
             limit=1,
-            where_cols=_col_values_dict,
+            where_cols=tuple(_col_values_dict),
         )
 
         with self._con as con:
@@ -424,10 +432,14 @@ class ORMBase(Generic[TableSpecType]):
             _col_values_dict = {}
         _col_values_dict.update(col_values)
 
+        _parsed_order_by = None
+        if _order_by:
+            _parsed_order_by = tuple(_order_by)
+
         delete_stmt = self.orm_table_spec.table_delete_stmt(
             delete_from=self.orm_table_name,
             limit=_limit,
-            order_by=_order_by,
+            order_by=_parsed_order_by,
             returning_cols=None,
             where_cols=tuple(_col_values_dict),
         )
@@ -471,11 +483,15 @@ class ORMBase(Generic[TableSpecType]):
             _col_values_dict = {}
         _col_values_dict.update(col_values)
 
+        _parsed_order_by = None
+        if _order_by:
+            _parsed_order_by = tuple(_order_by)
+
         delete_stmt = self.orm_table_spec.table_delete_stmt(
             delete_from=self.orm_table_name,
             limit=_limit,
-            order_by=_order_by,
-            returning_cols=_returning_cols,
+            order_by=_parsed_order_by,
+            returning_cols=tuple(_returning_cols),
             where_cols=tuple(_col_values_dict),
         )
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -273,7 +273,7 @@ class ORMBase(Generic[TableSpecType]):
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
             _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
-            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have lower priority over
                 the one specified by <_col_vlues_dict>.
 
         Raises:
@@ -282,9 +282,8 @@ class ORMBase(Generic[TableSpecType]):
         Yields:
             Generator[TableSpecType, None, None]: A generator that can be used to yield entry from result.
         """
-        if not _col_values_dict:
-            _col_values_dict = {}
-        _col_values_dict.update(col_values)
+        if _col_values_dict:
+            col_values.update(_col_values_dict)
 
         _parsed_order_by = None
         if _order_by:
@@ -295,11 +294,11 @@ class ORMBase(Generic[TableSpecType]):
             distinct=_distinct,
             order_by=_parsed_order_by,
             limit=_limit,
-            where_cols=tuple(_col_values_dict),
+            where_cols=tuple(col_values),
         )
 
         with self._con as con:
-            _cur = con.execute(table_select_stmt, _col_values_dict)
+            _cur = con.execute(table_select_stmt, col_values)
             if _row_factory is not None:
                 _cur.row_factory = _row_factory
             yield from _cur
@@ -325,7 +324,7 @@ class ORMBase(Generic[TableSpecType]):
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
             _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
-            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have lower priority over
                 the one specified by <_col_vlues_dict>.
 
         Raises:
@@ -334,9 +333,8 @@ class ORMBase(Generic[TableSpecType]):
         Returns:
             Exactly one <TableSpecType> entry, or None if not hit.
         """
-        if not _col_values_dict:
-            _col_values_dict = {}
-        _col_values_dict.update(col_values)
+        if _col_values_dict:
+            col_values.update(_col_values_dict)
 
         _parsed_order_by = None
         if _order_by:
@@ -347,11 +345,11 @@ class ORMBase(Generic[TableSpecType]):
             distinct=_distinct,
             order_by=_parsed_order_by,
             limit=1,
-            where_cols=tuple(_col_values_dict),
+            where_cols=tuple(col_values),
         )
 
         with self._con as con:
-            _cur = con.execute(table_select_stmt, _col_values_dict)
+            _cur = con.execute(table_select_stmt, col_values)
             if _row_factory is not None:
                 _cur.row_factory = _row_factory
             return _cur.fetchone()
@@ -422,15 +420,14 @@ class ORMBase(Generic[TableSpecType]):
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
             _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
-            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have lower priority over
                 the one specified by <_col_vlues_dict>.
 
         Returns:
             int: The num of entries deleted.
         """
-        if not _col_values_dict:
-            _col_values_dict = {}
-        _col_values_dict.update(col_values)
+        if _col_values_dict:
+            col_values.update(_col_values_dict)
 
         _parsed_order_by = None
         if _order_by:
@@ -441,11 +438,11 @@ class ORMBase(Generic[TableSpecType]):
             limit=_limit,
             order_by=_parsed_order_by,
             returning_cols=None,
-            where_cols=tuple(_col_values_dict),
+            where_cols=tuple(col_values),
         )
 
         with self._con as con:
-            _cur = con.execute(delete_stmt, _col_values_dict)
+            _cur = con.execute(delete_stmt, col_values)
             if _row_factory:
                 _cur.row_factory = _row_factory
             return _cur.rowcount
@@ -472,16 +469,15 @@ class ORMBase(Generic[TableSpecType]):
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
             _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
-            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have lower priority over
                 the one specified by <_col_vlues_dict>.
 
         Returns:
             Generator[TableSpecType, None, None]: If <_returning_cols> is defined, returns a generator which can
                 be used to yield the deleted entries from.
         """
-        if not _col_values_dict:
-            _col_values_dict = {}
-        _col_values_dict.update(col_values)
+        if _col_values_dict:
+            col_values.update(_col_values_dict)
 
         _parsed_order_by = None
         if _order_by:
@@ -492,12 +488,12 @@ class ORMBase(Generic[TableSpecType]):
             limit=_limit,
             order_by=_parsed_order_by,
             returning_cols=tuple(_returning_cols),
-            where_cols=tuple(_col_values_dict),
+            where_cols=tuple(col_values),
         )
 
         def _gen():
             with self._con as con:
-                _cur = con.execute(delete_stmt, _col_values_dict)
+                _cur = con.execute(delete_stmt, col_values)
                 if _row_factory is not None:
                     _cur.row_factory = _row_factory
                 yield from _cur

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -483,11 +483,17 @@ class ORMBase(Generic[TableSpecType]):
         if _order_by:
             _parsed_order_by = tuple(_order_by)
 
+        _parsed_returning_cols = None
+        if _returning_cols == "*":
+            _parsed_returning_cols = "*"
+        else:
+            _parsed_returning_cols = tuple(_returning_cols)
+
         delete_stmt = self.orm_table_spec.table_delete_stmt(
             delete_from=self.orm_table_name,
             limit=_limit,
             order_by=_parsed_order_by,
-            returning_cols=tuple(_returning_cols),
+            returning_cols=_parsed_returning_cols,
             where_cols=tuple(col_values),
         )
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -16,9 +16,14 @@ from typing import (
 from typing_extensions import ParamSpec
 
 from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
-from simple_sqlite3_orm._sqlite_spec import INSERT_OR, ORDER_DIRECTION
+from simple_sqlite3_orm._sqlite_spec import INSERT_OR
 from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType
-from simple_sqlite3_orm._types import ConnectionFactoryType, RowFactoryType
+from simple_sqlite3_orm._typing import (
+    ColsDefinition,
+    ColsDefinitionWithDirection,
+    ConnectionFactoryType,
+    RowFactoryType,
+)
 
 P = ParamSpec("P")
 RT = TypeVar("RT")
@@ -223,7 +228,7 @@ class ORMBase(Generic[TableSpecType]):
         self,
         *,
         index_name: str,
-        index_keys: tuple[str, ...],
+        index_keys: ColsDefinition | ColsDefinitionWithDirection,
         allow_existed: bool = False,
         unique: bool = False,
     ) -> None:
@@ -231,7 +236,7 @@ class ORMBase(Generic[TableSpecType]):
 
         Args:
             index_name (str): The name of the index.
-            index_keys (tuple[str, ...]): The columns for the index.
+            index_keys (ColsDefinition | ColsDefinitionWithDirection): The columns for the index.
             allow_existed (bool, optional): Not abort on index already created. Defaults to False.
             unique (bool, optional): Not allow duplicated entries in the index. Defaults to False.
 
@@ -252,20 +257,24 @@ class ORMBase(Generic[TableSpecType]):
         self,
         *,
         _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        _order_by: ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
         _row_factory: RowFactoryType | None = None,
+        _col_values_dict: dict[str, Any] | None = None,
         **col_values: Any,
     ) -> Generator[TableSpecType | Any]:
         """Select entries from the table accordingly.
 
         Args:
             _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
-            _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
+            _order_by (ColsDefinitionWithDirection | None, optional):
                 Order the result accordingly. Defaults to None, not sorting the result.
             _limit (int | None, optional): Limit the number of result entries. Defaults to None.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
+            _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+                the one specified by <_col_vlues_dict>.
 
         Raises:
             sqlite3.DatabaseError on failed sql execution.
@@ -273,16 +282,20 @@ class ORMBase(Generic[TableSpecType]):
         Yields:
             Generator[TableSpecType, None, None]: A generator that can be used to yield entry from result.
         """
+        if not _col_values_dict:
+            _col_values_dict = {}
+        _col_values_dict.update(col_values)
+
         table_select_stmt = self.orm_table_spec.table_select_stmt(
             select_from=self.orm_table_name,
             distinct=_distinct,
             order_by=_order_by,
             limit=_limit,
-            where_cols=tuple(col_values),
+            where_cols=_col_values_dict,
         )
 
         with self._con as con:
-            _cur = con.execute(table_select_stmt, col_values)
+            _cur = con.execute(table_select_stmt, _col_values_dict)
             if _row_factory is not None:
                 _cur.row_factory = _row_factory
             yield from _cur
@@ -291,8 +304,9 @@ class ORMBase(Generic[TableSpecType]):
         self,
         *,
         _distinct: bool = False,
-        _order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        _order_by: ColsDefinitionWithDirection | None = None,
         _row_factory: RowFactoryType | None = None,
+        _col_values_dict: dict[str, Any] | None = None,
         **col_values: Any,
     ) -> TableSpecType | Any | None:
         """Select exactly one entry from the table accordingly.
@@ -302,10 +316,13 @@ class ORMBase(Generic[TableSpecType]):
 
         Args:
             _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
-            _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
+            _order_by (ColsDefinitionWithDirection | None, optional):
                 Order the result accordingly. Defaults to None, not sorting the result.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
+            _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+                the one specified by <_col_vlues_dict>.
 
         Raises:
             sqlite3.DatabaseError on failed sql execution.
@@ -313,16 +330,20 @@ class ORMBase(Generic[TableSpecType]):
         Returns:
             Exactly one <TableSpecType> entry, or None if not hit.
         """
+        if not _col_values_dict:
+            _col_values_dict = {}
+        _col_values_dict.update(col_values)
+
         table_select_stmt = self.orm_table_spec.table_select_stmt(
             select_from=self.orm_table_name,
             distinct=_distinct,
             order_by=_order_by,
             limit=1,
-            where_cols=tuple(col_values),
+            where_cols=_col_values_dict,
         )
 
         with self._con as con:
-            _cur = con.execute(table_select_stmt, col_values)
+            _cur = con.execute(table_select_stmt, _col_values_dict)
             if _row_factory is not None:
                 _cur.row_factory = _row_factory
             return _cur.fetchone()
@@ -378,33 +399,41 @@ class ORMBase(Generic[TableSpecType]):
     def orm_delete_entries(
         self,
         *,
-        _order_by: tuple[str | tuple[str, ORDER_DIRECTION]] | None = None,
+        _order_by: ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
         _row_factory: RowFactoryType | None = None,
-        **cols_value: Any,
+        _col_values_dict: dict[str, Any] | None = None,
+        **col_values: Any,
     ) -> int:
         """Delete entries from the table accordingly.
 
         Args:
-            _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION]] | None, optional): Order the matching entries
+            _order_by (ColsDefinitionWithDirection | None, optional): Order the matching entries
                 before executing the deletion, used together with <_limit>. Defaults to None.
             _limit (int | None, optional): Only delete <_limit> number of entries. Defaults to None.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
+            _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+                the one specified by <_col_vlues_dict>.
 
         Returns:
             int: The num of entries deleted.
         """
+        if not _col_values_dict:
+            _col_values_dict = {}
+        _col_values_dict.update(col_values)
+
         delete_stmt = self.orm_table_spec.table_delete_stmt(
             delete_from=self.orm_table_name,
             limit=_limit,
             order_by=_order_by,
             returning_cols=None,
-            where_cols=tuple(cols_value),
+            where_cols=tuple(_col_values_dict),
         )
 
         with self._con as con:
-            _cur = con.execute(delete_stmt, cols_value)
+            _cur = con.execute(delete_stmt, _col_values_dict)
             if _row_factory:
                 _cur.row_factory = _row_factory
             return _cur.rowcount
@@ -412,39 +441,47 @@ class ORMBase(Generic[TableSpecType]):
     def orm_delete_entries_with_returning(
         self,
         *,
-        _order_by: tuple[str | tuple[str, ORDER_DIRECTION]] | None = None,
+        _order_by: ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
-        _returning_cols: tuple[str, ...] | Literal["*"],
+        _returning_cols: ColsDefinition | Literal["*"],
         _row_factory: RowFactoryType | None = None,
-        **cols_value: Any,
+        _col_values_dict: dict[str, Any] | None = None,
+        **col_values: Any,
     ) -> Generator[TableSpecType]:
         """Delete entries from the table accordingly.
 
         NOTE that only sqlite3 version >= 3.35 supports returning statement.
 
         Args:
-            _order_by (tuple[str  |  tuple[str, ORDER_DIRECTION]] | None, optional): Order the matching entries
+            _order_by (ColsDefinitionWithDirection | None, optional): Order the matching entries
                 before executing the deletion, used together with <_limit>. Defaults to None.
             _limit (int | None, optional): Only delete <_limit> number of entries. Defaults to None.
-            _returning_cols (tuple[str, ...] | Literal["*"] ): Return the deleted entries on execution.
+            _returning_cols (ColsDefinition | Literal["*"] ): Return the deleted entries on execution.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
+            _col_values_dict (dict[str, Any] | None, optional): provide col/value pairs by dict. Defaults to None.
+            **col_values: provide col/value pairs by kwargs. Col/value pairs in <col_values> have higher priority over
+                the one specified by <_col_vlues_dict>.
 
         Returns:
             Generator[TableSpecType, None, None]: If <_returning_cols> is defined, returns a generator which can
                 be used to yield the deleted entries from.
         """
+        if not _col_values_dict:
+            _col_values_dict = {}
+        _col_values_dict.update(col_values)
+
         delete_stmt = self.orm_table_spec.table_delete_stmt(
             delete_from=self.orm_table_name,
             limit=_limit,
             order_by=_order_by,
             returning_cols=_returning_cols,
-            where_cols=tuple(cols_value),
+            where_cols=tuple(_col_values_dict),
         )
 
         def _gen():
             with self._con as con:
-                _cur = con.execute(delete_stmt, cols_value)
+                _cur = con.execute(delete_stmt, _col_values_dict)
                 if _row_factory is not None:
                     _cur.row_factory = _row_factory
                 yield from _cur

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -257,7 +257,7 @@ class ORMBase(Generic[TableSpecType]):
         self,
         *,
         _distinct: bool = False,
-        _order_by: ColsDefinitionWithDirection | None = None,
+        _order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
         _row_factory: RowFactoryType | None = None,
         _col_values_dict: dict[str, Any] | None = None,
@@ -267,7 +267,7 @@ class ORMBase(Generic[TableSpecType]):
 
         Args:
             _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
-            _order_by (ColsDefinitionWithDirection | None, optional):
+            _order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional):
                 Order the result accordingly. Defaults to None, not sorting the result.
             _limit (int | None, optional): Limit the number of result entries. Defaults to None.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
@@ -304,7 +304,7 @@ class ORMBase(Generic[TableSpecType]):
         self,
         *,
         _distinct: bool = False,
-        _order_by: ColsDefinitionWithDirection | None = None,
+        _order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         _row_factory: RowFactoryType | None = None,
         _col_values_dict: dict[str, Any] | None = None,
         **col_values: Any,
@@ -316,7 +316,7 @@ class ORMBase(Generic[TableSpecType]):
 
         Args:
             _distinct (bool, optional): Deduplicate and only return unique entries. Defaults to False.
-            _order_by (ColsDefinitionWithDirection | None, optional):
+            _order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional):
                 Order the result accordingly. Defaults to None, not sorting the result.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
                 as row factory, set this argument to use different row factory. Defaults to None.
@@ -399,7 +399,7 @@ class ORMBase(Generic[TableSpecType]):
     def orm_delete_entries(
         self,
         *,
-        _order_by: ColsDefinitionWithDirection | None = None,
+        _order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
         _row_factory: RowFactoryType | None = None,
         _col_values_dict: dict[str, Any] | None = None,
@@ -408,7 +408,7 @@ class ORMBase(Generic[TableSpecType]):
         """Delete entries from the table accordingly.
 
         Args:
-            _order_by (ColsDefinitionWithDirection | None, optional): Order the matching entries
+            _order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional): Order the matching entries
                 before executing the deletion, used together with <_limit>. Defaults to None.
             _limit (int | None, optional): Only delete <_limit> number of entries. Defaults to None.
             _row_factory (RowFactoryType | None, optional): By default ORMBase will use <table_spec>.table_row_factory
@@ -441,7 +441,7 @@ class ORMBase(Generic[TableSpecType]):
     def orm_delete_entries_with_returning(
         self,
         *,
-        _order_by: ColsDefinitionWithDirection | None = None,
+        _order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         _limit: int | None = None,
         _returning_cols: ColsDefinition | Literal["*"],
         _row_factory: RowFactoryType | None = None,
@@ -453,7 +453,7 @@ class ORMBase(Generic[TableSpecType]):
         NOTE that only sqlite3 version >= 3.35 supports returning statement.
 
         Args:
-            _order_by (ColsDefinitionWithDirection | None, optional): Order the matching entries
+            _order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional): Order the matching entries
                 before executing the deletion, used together with <_limit>. Defaults to None.
             _limit (int | None, optional): Only delete <_limit> number of entries. Defaults to None.
             _returning_cols (ColsDefinition | Literal["*"] ): Return the deleted entries on execution.

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -14,7 +14,7 @@ from typing_extensions import Concatenate, ParamSpec
 from simple_sqlite3_orm._orm._base import ORMBase, RowFactorySpecifier
 from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
 from simple_sqlite3_orm._table_spec import TableSpecType
-from simple_sqlite3_orm._types import ConnectionFactoryType
+from simple_sqlite3_orm._typing import ConnectionFactoryType
 
 P = ParamSpec("P")
 RT = TypeVar("RT")

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -8,11 +8,8 @@ from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from typing_extensions import Self
 
-from simple_sqlite3_orm._sqlite_spec import (
-    INSERT_OR,
-    ORDER_DIRECTION,
-    SQLiteBuiltInFuncs,
-)
+from simple_sqlite3_orm._sqlite_spec import INSERT_OR, SQLiteBuiltInFuncs
+from simple_sqlite3_orm._typing import ColsDefinition, ColsDefinitionWithDirection
 from simple_sqlite3_orm._utils import (
     ConstrainRepr,
     TypeAffinityRepr,
@@ -27,7 +24,7 @@ class TableSpec(BaseModel):
     @classmethod
     def _generate_where_stmt(
         cls,
-        where_cols: tuple[str, ...] | None = None,
+        where_cols: ColsDefinition | None = None,
         where_stmt: str | None = None,
     ) -> str:
         if where_stmt:
@@ -42,7 +39,7 @@ class TableSpec(BaseModel):
     @classmethod
     def _generate_order_by_stmt(
         cls,
-        order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         order_by_stmt: str | None = None,
     ) -> str:
         if order_by_stmt:
@@ -62,7 +59,7 @@ class TableSpec(BaseModel):
     @classmethod
     def _generate_returning_stmt(
         cls,
-        returning_cols: tuple[str, ...] | Literal["*"] | None = None,
+        returning_cols: ColsDefinition | Literal["*"] | None = None,
         returning_stmt: str | None = None,
     ) -> str:
         if returning_stmt:
@@ -87,7 +84,7 @@ class TableSpec(BaseModel):
 
     @classmethod
     @lru_cache
-    def table_check_cols(cls, cols: tuple[str, ...]) -> None:
+    def table_check_cols(cls, cols: ColsDefinition) -> None:
         """Ensure all cols in <cols> existed in the table definition.
 
         Raises:
@@ -161,7 +158,7 @@ class TableSpec(BaseModel):
         *,
         table_name: str,
         index_name: str,
-        index_cols: tuple[str | tuple[str, ORDER_DIRECTION], ...],
+        index_cols: ColsDefinition | ColsDefinitionWithDirection,
         if_not_exists: bool = False,
         unique: bool = False,
     ) -> str:
@@ -309,10 +306,10 @@ class TableSpec(BaseModel):
         cls,
         *,
         insert_into: str,
-        insert_cols: tuple[str, ...] | None = None,
+        insert_cols: ColsDefinition | None = None,
         insert_default: bool = False,
         or_option: INSERT_OR | None = None,
-        returning_cols: tuple[str, ...] | Literal["*"] | None = None,
+        returning_cols: ColsDefinition | Literal["*"] | None = None,
         returning_stmt: str | None = None,
     ) -> str:
         """Get sql for inserting row(s) into <table_name>.
@@ -321,12 +318,12 @@ class TableSpec(BaseModel):
 
         Args:
             insert_into (str): The name of table insert into.
-            insert_cols (tuple[str, ...] | None, optional): The cols to be assigned for entry to be inserted.
+            insert_cols (ColsDefinition | None, optional): The cols to be assigned for entry to be inserted.
                 Defaults to None, means we will assign all cols of the row.
             insert_default (bool, optional): No values will be assigned, all cols will be assigned with
                 default value, this precedes the <insert_cols> param. Defaults to False.
             or_option (INSERT_OR | None, optional): The fallback operation if insert failed. Defaults to None.
-            returning_cols (tuple[str, ...] | Literal["*"] | None): Which cols are included in the returned entries.
+            returning_cols (ColsDefinition | Literal["*"] | None): Which cols are included in the returned entries.
                 Defaults to None.
             returning_stmt (str | None, optional): The full returning statement string, this
                 precedes the <returning_cols> param. Defaults to None.
@@ -371,7 +368,7 @@ class TableSpec(BaseModel):
         select_from: str,
         batch_idx: int | None = None,
         batch_size: int | None = None,
-        order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         order_by_stmt: str | None = None,
         distinct: bool = False,
     ) -> str:
@@ -383,7 +380,7 @@ class TableSpec(BaseModel):
             select_from (str): The table name for the generated statement.
             batch_idx (int | None, optional): If specified, the batch index of current page. Defaults to None.
             batch_size (int | None, optional): If specified, the batch size of each page. Defaults to None.
-            order_by (tuple[str | tuple[str, ORDER_DIRECTION], ...] | None, optional):
+            order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional):
                 A list of cols for ordering result. Defaults to None.
             order_by_stmt (str | None, optional): The order_by statement string, this
                 precedes the <order_by> param if set. Defaults to None.
@@ -426,12 +423,12 @@ class TableSpec(BaseModel):
         cls,
         *,
         select_from: str,
-        select_cols: tuple[str, ...] | Literal["*"] | str = "*",
+        select_cols: ColsDefinition | Literal["*"] | str = "*",
         function: SQLiteBuiltInFuncs | None = None,
         where_stmt: str | None = None,
-        where_cols: tuple[str, ...] | None = None,
-        group_by: tuple[str, ...] | None = None,
-        order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        where_cols: ColsDefinition | None = None,
+        group_by: ColsDefinition | None = None,
+        order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         order_by_stmt: str | None = None,
         limit: int | None = None,
         distinct: bool = False,
@@ -443,14 +440,14 @@ class TableSpec(BaseModel):
 
         Args:
             select_from (str): The table name for the generated statement.
-            select_cols (tuple[str, ...] | Literal["*"] | str, optional): A list of cols included in the result row. Defaults to "*".
+            select_cols (ColsDefinition | Literal["*"] | str, optional): A list of cols included in the result row. Defaults to "*".
             function (SQLiteBuiltInFuncs | None, optional): The sqlite3 function used in the selection. Defaults to None.
-            where_cols (tuple[str, ...] | None, optional): A list of cols to be compared in where
+            where_cols (ColsDefinition | None, optional): A list of cols to be compared in where
                 statement. Defaults to None.
             where_stmt (str | None, optional): The full where statement string, this
                 precedes the <where_cols> param if set. Defaults to None.
-            group_by (tuple[str, ...] | None, optional): A list of cols for group_by statement. Defaults to None.
-            order_by (Iterable[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
+            group_by (ColsDefinition | None, optional): A list of cols for group_by statement. Defaults to None.
+            order_by ( ColsDefinition | ColsDefinitionWithDirection | None, optional):
                 A list of cols for ordering result. Defaults to None.
             order_by_stmt (str | None, optional): The order_by statement string, this
                 precedes the <order_by> param if set. Defaults to None.
@@ -492,12 +489,12 @@ class TableSpec(BaseModel):
         cls,
         *,
         delete_from: str,
-        where_cols: tuple[str, ...] | None = None,
+        where_cols: ColsDefinition | None = None,
         where_stmt: str | None = None,
-        order_by: tuple[str | tuple[str, ORDER_DIRECTION], ...] | None = None,
+        order_by: ColsDefinition | ColsDefinitionWithDirection | None = None,
         order_by_stmt: str | None = None,
         limit: int | str | None = None,
-        returning_cols: tuple[str, ...] | Literal["*"] | None = None,
+        returning_cols: ColsDefinition | Literal["*"] | None = None,
         returning_stmt: str | None = None,
     ) -> str:
         """Get sql for deleting row(s) from <table_name> with specifying col value(s).
@@ -518,15 +515,15 @@ class TableSpec(BaseModel):
         Args:
             delete_from (str): The table name for the generated statement.
             limit (int | str | None, optional): The value for limit expr. Defaults to None.
-            order_by (Iterable[str  |  tuple[str, ORDER_DIRECTION]] | None, optional):
+            order_by (ColsDefinition | ColsDefinitionWithDirection | None, optional):
                 A list of cols for ordering result. Defaults to None.
             order_by_stmt (str | None, optional): The order_by statement string, this
                 precedes the <order_by> param if set. Defaults to None.
-            where_cols (tuple[str, ...] | None, optional): A list of cols to be compared in where
+            where_cols (ColsDefinition | None, optional): A list of cols to be compared in where
                 statement. Defaults to None.
             where_stmt (str | None, optional): The full where statement string, this
                 precedes the <where_cols> param if set. Defaults to None.
-            returning_cols (tuple[str, ...] | Literal["*"] | None): Which cols are included in the returned entries.
+            returning_cols (ColsDefinition | Literal["*"] | None): Which cols are included in the returned entries.
                 Defaults to None.
             returning_stmt (str | None, optional): The full returning statement string, this
                 precedes the <returning_cols> param. Defaults to None.

--- a/src/simple_sqlite3_orm/_types.py
+++ b/src/simple_sqlite3_orm/_types.py
@@ -3,17 +3,10 @@
 from __future__ import annotations
 
 import datetime
-import sqlite3
-from sqlite3 import Cursor, Row
-from typing import Any, Callable
+from typing import Any
 
 from pydantic import BeforeValidator, PlainSerializer
 from typing_extensions import Annotated
-
-RowFactoryType = Callable[[Cursor, Row], Any]
-"""Type hint for callable that can be used as sqlite3 row_factory."""
-
-ConnectionFactoryType = Callable[[], sqlite3.Connection]
 
 #
 # ------ datetime related ------ #

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -1,0 +1,19 @@
+"""Typing helpers definition."""
+
+from __future__ import annotations
+
+import sqlite3
+from sqlite3 import Cursor, Row
+from typing import Any, Callable, TypeAlias
+
+from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
+
+RowFactoryType = Callable[[Cursor, Row], Any]
+"""Type hint for callable that can be used as sqlite3 row_factory."""
+
+ConnectionFactoryType = Callable[[], sqlite3.Connection]
+
+ColsDefinitionWithDirection: TypeAlias = "tuple[str | tuple[str, ORDER_DIRECTION], ...]"
+ColsDefinition: TypeAlias = (
+    "tuple[str, ...] | dict[str, Any] | ColsDefinitionWithDirection"
+)

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -14,6 +14,4 @@ RowFactoryType = Callable[[Cursor, Row], Any]
 ConnectionFactoryType = Callable[[], sqlite3.Connection]
 
 ColsDefinitionWithDirection: TypeAlias = "tuple[str | tuple[str, ORDER_DIRECTION], ...]"
-ColsDefinition: TypeAlias = (
-    "tuple[str, ...] | dict[str, Any] | ColsDefinitionWithDirection"
-)
+ColsDefinition: TypeAlias = "tuple[str, ...] | dict[str, Any]"

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import sqlite3
 from sqlite3 import Cursor, Row
-from typing import Any, Callable, TypeAlias
+from typing import Any, Callable
+
+from typing_extensions import TypeAlias
 
 from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
 


### PR DESCRIPTION
## Introduction

This PR introduces the following changes:
1. ORM: now also takes dict as input when specifying col/value pairs as condition(like for generating where_statement).
2. typing: introduce and use ColsDefinition and ColsDefinitionWithDirection type for specifying cols.
3. ORM: use new ColsDefinition and ColsDefinitionWithDirection to type args specifying cols.