### PR TITLE
refactor: ORM: iter_all_with_pagination: partially revert #73 and better handle table with holes  

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -269,6 +269,8 @@ class TableSpec(BaseModel):
     ) -> Self:
         """A raw row_factory that converts the input _row to TableSpec instance.
 
+        NOTE that this method expects the input row match the table row spec EXACTLY.
+
         Args:
             _row (tuple[Any, ...]): the raw table row as tuple.
             with_validation (bool): if set to False, will use pydantic model_construct to directly

--- a/tests/sample_db/table.py
+++ b/tests/sample_db/table.py
@@ -123,3 +123,9 @@ class SampleTable(TableSpec):
     ]
     prim_key_magicf: float
     prim_key_bln: bool
+
+    def __hash__(self) -> int:
+        return hash(self.prim_key)
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, self.__class__) and value.prim_key == self.prim_key

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -95,14 +95,16 @@ class TestWithSampleDB:
 
     def test_select_all_entries(self, setup_test_data: dict[str, SampleTable]):
         logger.info("test lookup entries")
-        for _cnt, _entry in enumerate(
-            self.orm_inst.orm_select_all_with_pagination(
-                batch_size=SELECT_ALL_BATCH_SIZE
-            ),
-            start=1,
+
+        _looked_up = set()
+        for _entry in self.orm_inst.orm_select_all_with_pagination(
+            batch_size=SELECT_ALL_BATCH_SIZE
         ):
             assert setup_test_data[_entry.prim_key] == _entry
-        assert _cnt == len(setup_test_data)
+            _looked_up.add(_entry)
+
+        assert len(_looked_up) == len(setup_test_data)
+        assert all(_entry in _looked_up for _entry in setup_test_data.values())
 
     def test_delete_entries(
         self,


### PR DESCRIPTION
## Introduction

This PR partially revert the changes to iter_all_with_pagination API introduced in #73 , and refines the implementation to better handle table with holes by changing the termination condition to all the rows being fetched.

Other changes:
1. update tests to better test iter_all API, now will check all the entries in test data set are fetched.