### PR TITLE
fix: mutli-thread ORM pool: use bounded queue for thread context to fix high peak memory usage

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -25,7 +25,7 @@ _global_shutdown = False
 MAX_QUEUE_SIZE = 64
 
 
-def _python_exit():
+def _python_exit():  # pragma: no cover
     global _global_shutdown
     _global_shutdown = True
 

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
+import time
 from collections.abc import AsyncGenerator, Callable, Generator
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Generic, TypeVar
 
 from typing_extensions import Concatenate, ParamSpec, Self
@@ -21,6 +22,7 @@ P = ParamSpec("P")
 RT = TypeVar("RT")
 
 _global_shutdown = False
+MAX_QUEUE_SIZE = 64
 
 
 def _python_exit():
@@ -57,24 +59,28 @@ def _wrap_generator_with_async_ctx(
 ):
     async def _wrapped(self: AsyncORMBase, *args: P.args, **kwargs: P.kwargs):
         _orm_threadpool = self._orm_threadpool
-        _async_queue = asyncio.Queue(maxsize=16)
+        _async_queue = asyncio.Queue()
+
+        _put_queue_cb = partial(
+            self._loop.call_soon_threadsafe, _async_queue.put_nowait
+        )
 
         def _in_thread():
             global _global_shutdown
             _thread_scope_orm = _orm_threadpool._thread_scope_orm
-            _schedule_callback = self._loop.call_soon_threadsafe
 
-            # when the thread which loop is at exits, the _schedule_callback should
-            #   return immediately with RuntimeError as loop is closed.
             try:
                 for entry in func(_thread_scope_orm, *args, **kwargs):
-                    if _global_shutdown:
-                        return
-                    _schedule_callback(_async_queue.put, entry)
+                    while not _global_shutdown:
+                        if _async_queue.qsize() > MAX_QUEUE_SIZE:
+                            time.sleep(0.1)
+                            continue
+                        _put_queue_cb(entry)
+                        break
             except Exception as e:
-                _schedule_callback(_async_queue.put, e)
+                _put_queue_cb(e)
             finally:
-                _schedule_callback(_async_queue.put, _SENTINEL)
+                _put_queue_cb(_SENTINEL)
 
         _orm_threadpool._pool.submit(_in_thread)
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -518,8 +518,6 @@ class ORMBase(Generic[TableSpecType]):
         """Select all entries from the table accordingly with pagination.
 
         This is implemented by seek with rowid, so it will not work on without_rowid table.
-        NOTE that it is NOT recommended to use this method on table contains many holes.
-        If the table contains a lot of holes, this method might take unexpected extra long time to finish.
 
         Args:
             batch_size (int): The entry number for each page.

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -22,6 +22,7 @@ RT = TypeVar("RT")
 
 _global_shutdown = False
 _global_queue_weakset: WeakSet[queue.Queue] = WeakSet()
+MAX_QUEUE_SIZE = 64
 
 
 def _python_exit():
@@ -66,7 +67,7 @@ def _wrap_generator_with_thread_ctx(
     def _wrapped(
         self: ORMThreadPoolBase, *args: P.args, **kwargs: P.kwargs
     ) -> Generator[TableSpecType]:
-        _queue = queue.Queue(maxsize=16)
+        _queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
         _global_queue_weakset.add(_queue)
 
         def _in_thread():

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -30,18 +30,16 @@ def _python_exit():  # pragma: no cover
     _global_shutdown = True
 
     for _q in _global_queue_weakset:
-        while True:
-            # drain the queue to unblock the producer.
-            # Once the producer is unblocked, as the global_shutdown is set to True,
-            #  it will directly return.
-            with contextlib.suppress(queue.Empty):
-                while not _q.empty():
-                    _q.get_nowait()
+        # drain the queue to unblock the producer.
+        # Once the producer is unblocked, as the global_shutdown is set to True,
+        #  it will directly return.
+        with contextlib.suppress(queue.Empty):
+            while not _q.empty():
+                _q.get_nowait()
 
-            # then wake up the consumer
-            with contextlib.suppress(queue.Full):
-                _q.put(_SENTINEL, block=True, timeout=0.1)
-                break
+        # then wake up the consumer
+        with contextlib.suppress(queue.Full):
+            _q.put(_SENTINEL, block=True, timeout=0.1)
 
 
 atexit.register(_python_exit)

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -25,7 +25,7 @@ _global_queue_weakset: WeakSet[queue.Queue] = WeakSet()
 MAX_QUEUE_SIZE = 64
 
 
-def _python_exit():
+def _python_exit():  # pragma: no cover
     global _global_shutdown
     _global_shutdown = True
 

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -40,7 +40,7 @@ def _python_exit():
             # then wake up the consumer
             with contextlib.suppress(queue.Full):
                 _q.put(_SENTINEL, block=True, timeout=0.1)
-                return
+                break
 
 
 atexit.register(_python_exit)

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -41,7 +41,7 @@ class TestWithSampleDBWithAsyncIO:
         ) as pool:
             yield pool
 
-    @pytest_asyncio.fixture(autouse=True, loop_scope="class")
+    @pytest_asyncio.fixture(autouse=True, scope="class")
     async def start_timer(self) -> tuple[asyncio.Task[None], asyncio.Event]:
         _test_finished = asyncio.Event()
 


### PR DESCRIPTION
threadpool_orm is refactored to use bounded queue, but asyncio_orm uses self-spin with checking queue length to seemingly implements the bounded queue due to performance issue.