### PR TITLE
feat: ORM: add APIs for defining and bootstrapping new db

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
           coverage xml -o test_result/coverage.xml
 
       - name: SonarCloud code scanning
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         continue-on-error: true
         if: ${{ matrix.python_version == '3.12' }}
         env:

--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -13,7 +13,13 @@ from simple_sqlite3_orm._sqlite_spec import (
     SQLiteTypeAffinity,
     SQLiteTypeAffinityLiteral,
 )
-from simple_sqlite3_orm._table_spec import TableSpec, TableSpecType, gen_sql_stmt
+from simple_sqlite3_orm._table_spec import (
+    CreateIndexParams,
+    CreateTableParams,
+    TableSpec,
+    TableSpecType,
+    gen_sql_stmt,
+)
 from simple_sqlite3_orm._types import (
     DatetimeISO8601,
     DatetimeUnixTimestamp,
@@ -58,4 +64,7 @@ __all__ = [
     "version",
     "ColsDefinition",
     "ColsDefinitionWithDirection",
+    # typing helper
+    "CreateIndexParams",
+    "CreateTableParams",
 ]

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -198,6 +198,7 @@ class AsyncORMBase(ORMCommonBase[TableSpecType]):
         ORMBase.orm_select_all_with_pagination
     )
     orm_check_entry_exist = _wrap_with_async_ctx(ORMBase.orm_check_entry_exist)
+    orm_bootstrap_db = _wrap_with_async_ctx(ORMBase.orm_bootstrap_db)
 
 
 AsyncORMBaseType = TypeVar("AsyncORMBaseType", bound=AsyncORMBase)

--- a/src/simple_sqlite3_orm/_orm/_async.py
+++ b/src/simple_sqlite3_orm/_orm/_async.py
@@ -6,11 +6,11 @@ import logging
 import time
 from collections.abc import AsyncGenerator, Callable, Generator
 from functools import cached_property, partial
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from typing_extensions import Concatenate, ParamSpec, Self
 
-from simple_sqlite3_orm._orm._base import RowFactorySpecifier
+from simple_sqlite3_orm._orm._base import ORMCommonBase, RowFactorySpecifier
 from simple_sqlite3_orm._orm._multi_thread import ORMBase, ORMThreadPoolBase
 from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
 from simple_sqlite3_orm._table_spec import TableSpecType
@@ -103,7 +103,7 @@ def _wrap_generator_with_async_ctx(
     return _wrapped
 
 
-class AsyncORMBase(Generic[TableSpecType]):
+class AsyncORMBase(ORMCommonBase[TableSpecType]):
     """
     NOTE: the supoprt for async ORM is experimental! The APIs might be changed a lot
         in the following releases.
@@ -113,10 +113,6 @@ class AsyncORMBase(Generic[TableSpecType]):
 
     For the row_factory arg, please see ORMBase.__init__ for more details.
     """
-
-    orm_table_spec: type[TableSpecType]
-    _orm_table_name: str
-    """table_name for the ORM. This can be used for pinning table_name when creating ORM object."""
 
     def __init__(
         self,

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -4,6 +4,7 @@ import sqlite3
 import warnings
 from functools import cached_property, partial
 from typing import (
+    TYPE_CHECKING,
     Any,
     Generator,
     Generic,
@@ -95,10 +96,11 @@ class ORMBase(Generic[TableSpecType]):
     #
     # ------------ orm_boostrap APIs ------------ #
     #
-    _orm_table_name: str
-    """    
-    Directly setting this variable is DEPRECATED, use orm_boostrap_table_name instead.
-    """
+    if not TYPE_CHECKING:
+        _orm_table_name: str
+        """    
+        Directly setting this variable is DEPRECATED, use orm_boostrap_table_name instead.
+        """
     orm_boostrap_table_name: str
     orm_boostrap_create_table_params: str | CreateTableParams
     orm_boostrap_indexes_params: Iterable[str | CreateIndexParams] | None = None

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -76,32 +76,32 @@ class ORMCommonBase(Generic[TableSpecType]):
     orm_table_spec: type[TableSpecType]
 
     #
-    # ------------ orm_boostrap APIs ------------ #
+    # ------------ orm_bootstrap APIs ------------ #
     #
     if not TYPE_CHECKING:
         _orm_table_name: str
         """    
-        Directly setting this variable is DEPRECATED, use orm_boostrap_table_name instead.
+        Directly setting this variable is DEPRECATED, use orm_bootstrap_table_name instead.
         """
 
-    orm_boostrap_table_name: str
-    orm_boostrap_create_table_params: str | CreateTableParams
-    orm_boostrap_indexes_params: Iterable[str | CreateIndexParams] | None = None
+    orm_bootstrap_table_name: str
+    orm_bootstrap_create_table_params: str | CreateTableParams
+    orm_bootstrap_indexes_params: Iterable[str | CreateIndexParams] | None = None
 
     def __init_subclass__(cls, **kwargs) -> None:
         # check this class' dict to only get the name set during this subclass' creation
-        _set_table_name = cls.__dict__.get("orm_boostrap_table_name")
+        _set_table_name = cls.__dict__.get("orm_bootstrap_table_name")
 
         if _deprecated_set_table_name := cls.__dict__.get("_orm_table_name"):
             warnings.warn(
-                "Directly setting this variable is DEPRECATED, use orm_boostrap_table_name instead",
+                "Directly setting this variable is DEPRECATED, use orm_bootstrap_table_name instead",
                 stacklevel=1,
             )
             # For backward compatibility, still use the _orm_table_name if set in class creation namespace
             if not _set_table_name:
                 _set_table_name = _deprecated_set_table_name
 
-        # only override the _orm_table_name for the subclass when orm_boostrap_table_name is set
+        # only override the _orm_table_name for the subclass when orm_bootstrap_table_name is set
         #   in the class creation namespace.
         if _set_table_name:
             cls._orm_table_name = _set_table_name
@@ -126,28 +126,28 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         row_factory (RowFactorySpecifier): The connection scope row_factory to use. Default to "table_sepc".
     """
 
-    def orm_boostrap_db(self) -> None:
+    def orm_bootstrap_db(self) -> None:
         """Bootstrap the database this ORM connected to.
 
         This method will refer to the following attrs to setup table and indexes:
-        1. orm_boostrap_table_name: the name of table to be created.
-        2. orm_boostrap_create_table_params: the sqlite query to create the table,
+        1. orm_bootstrap_table_name: the name of table to be created.
+        2. orm_bootstrap_create_table_params: the sqlite query to create the table,
             it can be provided as sqlite query, or CreateTableParams for table_create_stmt
             to generate sqlite query from.
-        3. orm_boostrap_indexes_params: optional, a list of sqlite query or
+        3. orm_bootstrap_indexes_params: optional, a list of sqlite query or
             CreateIndexParams(for table_create_index_stmt to generate sqlite query from) to
             create indexes from.
 
         NOTE that ORM will not know whether the connected database has already been
-            boostrapped or not, this is up to caller to check.
+            bootstrapped or not, this is up to caller to check.
         """
         _table_name = self.orm_table_name
 
         try:
-            _table_create_stmt = self.orm_boostrap_create_table_params
+            _table_create_stmt = self.orm_bootstrap_create_table_params
         except AttributeError:
             raise ValueError(
-                "orm_bootstrap_db requires orm_boostrap_create_table_params to be set"
+                "orm_bootstrap_db requires orm_bootstrap_create_table_params to be set"
             ) from None
 
         if not isinstance(_table_create_stmt, str):
@@ -158,7 +158,7 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         with self.orm_con as conn:
             conn.execute(_table_create_stmt)
 
-        if _index_stmts := self.orm_boostrap_indexes_params:
+        if _index_stmts := self.orm_bootstrap_indexes_params:
             for _index_stmt in _index_stmts:
                 if not isinstance(_index_stmt, str):
                     _index_stmt = self.orm_table_spec.table_create_index_stmt(
@@ -183,7 +183,7 @@ class ORMBase(ORMCommonBase[TableSpecType]):
 
         if not getattr(self, "_orm_table_name", None):
             raise ValueError(
-                "table_name must be provided either by class variable orm_boostrap_table_name, "
+                "table_name must be provided either by class variable orm_bootstrap_table_name, "
                 "or by providing <table_name> keyword arg"
             )
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -80,7 +80,7 @@ class ORMCommonBase(Generic[TableSpecType]):
     #
     if not TYPE_CHECKING:
         _orm_table_name: str
-        """    
+        """
         Directly setting this variable is DEPRECATED, use orm_bootstrap_table_name instead.
         """
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -150,22 +150,22 @@ class ORMBase(ORMCommonBase[TableSpecType]):
                 "orm_bootstrap_db requires orm_bootstrap_create_table_params to be set"
             ) from None
 
-        if not isinstance(_table_create_stmt, str):
+        if isinstance(_table_create_stmt, dict):
             _table_create_stmt = self.orm_table_spec.table_create_stmt(
                 _table_name,
                 **_table_create_stmt,
             )
-        with self.orm_con as conn:
+        with self._con as conn:
             conn.execute(_table_create_stmt)
 
         if _index_stmts := self.orm_bootstrap_indexes_params:
             for _index_stmt in _index_stmts:
-                if not isinstance(_index_stmt, str):
+                if isinstance(_index_stmt, dict):
                     _index_stmt = self.orm_table_spec.table_create_index_stmt(
                         table_name=_table_name,
                         **_index_stmt,
                     )
-                with self.orm_con as conn:
+                with self._con as conn:
                     conn.execute(_index_stmt)
 
     def __init__(

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -106,7 +106,7 @@ class ORMBase(Generic[TableSpecType]):
     orm_boostrap_create_table_params: str | CreateTableParams
     orm_boostrap_indexes_params: Iterable[str | CreateIndexParams] | None = None
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         # check this class' dict to only get the name set during this subclass' creation
         _set_table_name = cls.__dict__.get("orm_boostrap_table_name")
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -72,25 +72,7 @@ def row_factory_setter(
     # do nothing means not changing connection scope row_factory
 
 
-class ORMBase(Generic[TableSpecType]):
-    """ORM layer for <TableSpecType>.
-
-    NOTE that instance of ORMBase cannot be used in multi-threaded environment.
-        Use ORMThreadPoolBase for multi-threaded environment.
-        For asyncio, use AsyncORMThreadPoolBase.
-
-    The underlying connection can be used in multiple connection for accessing different table in
-        the connected database.
-
-    Attributes:
-        con (sqlite3.Connection | ConnectionFactoryType): The sqlite3 connection used by this ORM, or a factory
-            function that returns a sqlite3.Connection object on calling.
-        table_name (str): The name of the table in the database <con> connected to. This field will take prior over the
-            table_name specified by _orm_table_name attr.
-        schema_name (str): The schema of the table if multiple databases are attached to <con>.
-        row_factory (RowFactorySpecifier): The connection scope row_factory to use. Default to "table_sepc".
-    """
-
+class ORMCommonBase(Generic[TableSpecType]):
     orm_table_spec: type[TableSpecType]
 
     #
@@ -123,6 +105,26 @@ class ORMBase(Generic[TableSpecType]):
         #   in the class creation namespace.
         if _set_table_name:
             cls._orm_table_name = _set_table_name
+
+
+class ORMBase(ORMCommonBase[TableSpecType]):
+    """ORM layer for <TableSpecType>.
+
+    NOTE that instance of ORMBase cannot be used in multi-threaded environment.
+        Use ORMThreadPoolBase for multi-threaded environment.
+        For asyncio, use AsyncORMThreadPoolBase.
+
+    The underlying connection can be used in multiple connection for accessing different table in
+        the connected database.
+
+    Attributes:
+        con (sqlite3.Connection | ConnectionFactoryType): The sqlite3 connection used by this ORM, or a factory
+            function that returns a sqlite3.Connection object on calling.
+        table_name (str): The name of the table in the database <con> connected to. This field will take prior over the
+            table_name specified by _orm_table_name attr.
+        schema_name (str): The schema of the table if multiple databases are attached to <con>.
+        row_factory (RowFactorySpecifier): The connection scope row_factory to use. Default to "table_sepc".
+    """
 
     def orm_boostrap_db(self) -> None:
         """Bootstrap the database this ORM connected to.

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -208,6 +208,7 @@ class ORMThreadPoolBase(ORMCommonBase[TableSpecType]):
         ORMBase.orm_select_all_with_pagination
     )
     orm_check_entry_exist = _wrap_with_thread_ctx(ORMBase.orm_check_entry_exist)
+    orm_bootstrap_db = _wrap_with_thread_ctx(ORMBase.orm_bootstrap_db)
 
 
 ORMThreadPoolBaseType = TypeVar("ORMThreadPoolBaseType", bound=ORMThreadPoolBase)

--- a/src/simple_sqlite3_orm/_orm/_multi_thread.py
+++ b/src/simple_sqlite3_orm/_orm/_multi_thread.py
@@ -7,12 +7,12 @@ import threading
 from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property, partial
-from typing import Generic, TypeVar
+from typing import TypeVar
 from weakref import WeakSet
 
 from typing_extensions import Concatenate, ParamSpec, Self
 
-from simple_sqlite3_orm._orm._base import ORMBase, RowFactorySpecifier
+from simple_sqlite3_orm._orm._base import ORMBase, ORMCommonBase, RowFactorySpecifier
 from simple_sqlite3_orm._orm._utils import parameterized_class_getitem
 from simple_sqlite3_orm._table_spec import TableSpecType
 from simple_sqlite3_orm._typing import ConnectionFactoryType
@@ -102,16 +102,12 @@ def _wrap_generator_with_thread_ctx(
     return _wrapped
 
 
-class ORMThreadPoolBase(Generic[TableSpecType]):
+class ORMThreadPoolBase(ORMCommonBase[TableSpecType]):
     """
     See https://www.sqlite.org/wal.html#concurrency for more details.
 
     For the row_factory arg, please see ORMBase.__init__ for more details.
     """
-
-    orm_table_spec: type[TableSpecType]
-    _orm_table_name: str
-    """table_name for the ORM. This can be used for pinning table_name when creating ORM object."""
 
     def __init__(
         self,

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Mapping
-from typing import Any, Iterable, Literal, TypeVar
+from typing import Any, Iterable, Literal, TypedDict, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from typing_extensions import Self
+from typing_extensions import NotRequired, Self
 
 from simple_sqlite3_orm._sqlite_spec import (
     INSERT_OR,
@@ -19,6 +19,20 @@ from simple_sqlite3_orm._utils import (
     gen_sql_stmt,
     lru_cache,
 )
+
+
+class CreateTableParams(TypedDict, total=False):
+    if_not_exists: bool
+    strict: bool
+    temporary: bool
+    without_rowid: bool
+
+
+class CreateIndexParams(TypedDict):
+    index_name: str
+    index_cols: tuple[str | tuple[str, ORDER_DIRECTION], ...]
+    if_not_exists: NotRequired[bool]
+    unique: NotRequired[bool]
 
 
 class TableSpec(BaseModel):

--- a/src/simple_sqlite3_orm/utils.py
+++ b/src/simple_sqlite3_orm/utils.py
@@ -124,7 +124,7 @@ def check_db_integrity(con: sqlite3.Connection, table_name: str | None = None) -
     """
     with con as con:
         if table_name:
-            cur = con.execute("PRAGMA integrity_check(?);", (table_name,))
+            cur = con.execute(f"PRAGMA integrity_check('{table_name}');")
         else:
             cur = con.execute("PRAGMA integrity_check;")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from typing import Callable, Generator, get_args
 import pytest
 
 from simple_sqlite3_orm import utils
-from tests.sample_db.orm import SampleDB
 from tests.sample_db.table import (
     Choice123,
     ChoiceABC,
@@ -96,27 +95,26 @@ def entry_to_lookup(setup_test_data: dict[str, SampleTable]) -> SampleTable:
 
 
 @pytest.fixture(scope="class")
-def setup_test_db(
+def setup_test_db_conn(
     tmp_path_factory: pytest.TempPathFactory,
-) -> Generator[SampleDB, None, None]:
+) -> Generator[sqlite3.Connection, None, None]:
     """Setup a single db connection for a test class."""
 
-    def _con_factory():
-        tmp_path = tmp_path_factory.mktemp("tmp_db_path")
-        db_file = tmp_path / "test_db_file.sqlite3"
+    tmp_path = tmp_path_factory.mktemp("tmp_db_path")
+    db_file = tmp_path / "test_db_file.sqlite3"
 
-        con = sqlite3.connect(db_file)
-
+    conn = sqlite3.connect(db_file)
+    try:
         # enable optimization
-        utils.enable_wal_mode(con, relax_sync_mode=True)
-        utils.enable_mmap(con)
-        utils.enable_tmp_store_at_memory(con)
-        return con
+        utils.enable_wal_mode(conn, relax_sync_mode=True)
+        utils.enable_mmap(conn)
+        utils.enable_tmp_store_at_memory(conn)
 
-    yield (orm := SampleDB(_con_factory, table_name=TABLE_NAME))
-
-    # finally, do a database integrity check after test operations
-    assert utils.check_db_integrity(orm.orm_con)
+        yield conn
+        # finally, do a database integrity check after test operations
+        assert utils.check_db_integrity(conn)
+    finally:
+        conn.close()
 
 
 DB_LOCK_WAIT_TIMEOUT = 30

--- a/tests/sample_db/orm.py
+++ b/tests/sample_db/orm.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
-from simple_sqlite3_orm import ORMBase
+from simple_sqlite3_orm import AsyncORMBase, ORMBase, ORMThreadPoolBase
+from tests.conftest import TABLE_NAME
 from tests.sample_db.table import SampleTable
 
 
 class SampleDB(ORMBase[SampleTable]):
     """ORM for SampleTable."""
+
+    orm_boostrap_table_name = TABLE_NAME
+
+
+class SampleDBAsyncio(AsyncORMBase[SampleTable]):
+    """Test connection pool with async API."""
+
+    orm_boostrap_table_name = TABLE_NAME
+
+
+class SampleDBConnectionPool(ORMThreadPoolBase[SampleTable]):
+    """Test connection pool."""
+
+    orm_boostrap_table_name = TABLE_NAME

--- a/tests/sample_db/orm.py
+++ b/tests/sample_db/orm.py
@@ -10,16 +10,16 @@ from tests.sample_db.table import SampleTable
 class SampleDB(ORMBase[SampleTable]):
     """ORM for SampleTable."""
 
-    orm_boostrap_table_name = TABLE_NAME
+    orm_bootstrap_table_name = TABLE_NAME
 
 
 class SampleDBAsyncio(AsyncORMBase[SampleTable]):
     """Test connection pool with async API."""
 
-    orm_boostrap_table_name = TABLE_NAME
+    orm_bootstrap_table_name = TABLE_NAME
 
 
 class SampleDBConnectionPool(ORMThreadPoolBase[SampleTable]):
     """Test connection pool."""
 
-    orm_boostrap_table_name = TABLE_NAME
+    orm_bootstrap_table_name = TABLE_NAME

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -168,16 +168,16 @@ class TestORMBase:
         ),
     ),
 )
-def test_boostrap(
+def test_bootstrap(
     table_name,
     create_table_params,
     create_indexes_params,
     setup_test_db_conn: sqlite3.Connection,
 ):
     class _ORM(SampleDB):
-        orm_boostrap_table_name = table_name
-        orm_boostrap_create_table_params = create_table_params
-        orm_boostrap_indexes_params = create_indexes_params
+        orm_bootstrap_table_name = table_name
+        orm_bootstrap_create_table_params = create_table_params
+        orm_bootstrap_indexes_params = create_indexes_params
 
     _orm = _ORM(setup_test_db_conn)
-    _orm.orm_boostrap_db()
+    _orm.orm_bootstrap_db()

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -7,17 +7,13 @@ from datetime import datetime
 
 import pytest
 
-from simple_sqlite3_orm import CreateIndexParams, CreateTableParams, ORMBase
+from simple_sqlite3_orm import CreateIndexParams, CreateTableParams
 from tests.conftest import SELECT_ALL_BATCH_SIZE, _generate_random_str
 from tests.sample_db._types import Mystr
 from tests.sample_db.orm import SampleDB
 from tests.sample_db.table import SampleTable
 
 logger = logging.getLogger(__name__)
-
-
-class ORMTest(ORMBase[SampleTable]):
-    _orm_table_name = "test_orm_table"
 
 
 _cur_timestamp = time.time()
@@ -48,17 +44,17 @@ class TestORMBase:
     @pytest.fixture(scope="class")
     def setup_connection(self):
         with sqlite3.connect(":memory:") as conn:
-            orm_inst = ORMTest(conn)
+            orm_inst = SampleDB(conn)
             yield orm_inst
 
     def test_create_without_rowid_table(self):
         """NOTE: to test select_all_with_pagination, we cannot specify without_rowid, so we
         create this test case dedicated for creating without_rowid table test."""
         with sqlite3.connect(":memory:") as conn:
-            orm_inst = ORMTest(conn)
+            orm_inst = SampleDB(conn)
             orm_inst.orm_create_table(without_rowid=True)
 
-    def test_create_table(self, setup_connection: ORMTest):
+    def test_create_table(self, setup_connection: SampleDB):
         setup_connection.orm_create_table(allow_existed=False)
 
         if sqlite3.sqlite_version_info < (3, 37, 0):
@@ -73,7 +69,7 @@ class TestORMBase:
         with pytest.raises(sqlite3.DatabaseError):
             setup_connection.orm_create_table(allow_existed=False)
 
-    def test_create_index(self, setup_connection: ORMTest):
+    def test_create_index(self, setup_connection: SampleDB):
         setup_connection.orm_create_index(
             index_name="idx_prim_key_sha256hash",
             index_keys=("prim_key_sha256hash",),
@@ -88,7 +84,7 @@ class TestORMBase:
                 allow_existed=False,
             )
 
-    def test_insert_entries(self, setup_connection: ORMTest):
+    def test_insert_entries(self, setup_connection: SampleDB):
         setup_connection.orm_insert_entries((entry_for_test,))
 
         with pytest.raises(sqlite3.DatabaseError):
@@ -96,7 +92,7 @@ class TestORMBase:
         setup_connection.orm_insert_entry(entry_for_test, or_option="ignore")
         setup_connection.orm_insert_entry(entry_for_test, or_option="replace")
 
-    def test_orm_execute(self, setup_connection: ORMTest):
+    def test_orm_execute(self, setup_connection: SampleDB):
         sql_stmt = setup_connection.orm_table_spec.table_select_stmt(
             select_from=setup_connection.orm_table_name,
             select_cols="*",
@@ -106,14 +102,14 @@ class TestORMBase:
         res = setup_connection.orm_execute(sql_stmt)
         assert res and res[0][0] > 0
 
-    def test_orm_check_entry_exist(self, setup_connection: ORMTest):
+    def test_orm_check_entry_exist(self, setup_connection: SampleDB):
         assert setup_connection.orm_check_entry_exist(prim_key=entry_for_test.prim_key)
         assert not setup_connection.orm_check_entry_exist(prim_key=Mystr("not_exist"))
 
-    def test_select_entry(self, setup_connection: ORMTest):
+    def test_select_entry(self, setup_connection: SampleDB):
         assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)
 
-    def test_select_entries(self, setup_connection: ORMTest):
+    def test_select_entries(self, setup_connection: SampleDB):
         select_result = setup_connection.orm_select_entries(
             _distinct=True,
             _order_by=(("key_id", "DESC"),),
@@ -125,7 +121,7 @@ class TestORMBase:
         assert len(select_result) == 1
         assert select_result[0] == entry_for_test
 
-    def test_select_all_entries(self, setup_connection: ORMTest):
+    def test_select_all_entries(self, setup_connection: SampleDB):
         select_result = setup_connection.orm_select_all_with_pagination(
             batch_size=SELECT_ALL_BATCH_SIZE
         )
@@ -134,13 +130,13 @@ class TestORMBase:
         assert len(select_result) == 1
         assert select_result[0] == entry_for_test
 
-    def test_function_call(self, setup_connection: ORMTest):
+    def test_function_call(self, setup_connection: SampleDB):
         with setup_connection.orm_con as con:
-            cur = con.execute(f"SELECT count(*) FROM {ORMTest._orm_table_name};")
+            cur = con.execute(f"SELECT count(*) FROM {SampleDB._orm_table_name};")
             res = cur.fetchone()
             assert res[0] == 1
 
-    def test_delete_entries(self, setup_connection: ORMTest):
+    def test_delete_entries(self, setup_connection: SampleDB):
         assert setup_connection.orm_delete_entries(key_id=entry_for_test.key_id) == 1
 
 

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -145,8 +145,12 @@ class TestORMBase:
     (
         (
             "test_1",
+            # NOTE: strict param only supported at sqlite3 >= 3.37
             CreateTableParams(
-                if_not_exists=True, strict=True, temporary=True, without_rowid=True
+                if_not_exists=True,
+                temporary=True,
+                strict=True if sqlite3.sqlite_version_info >= (3, 37, 0) else False,
+                without_rowid=True,
             ),
             None,
         ),

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -9,9 +9,9 @@ from typing import Callable
 import pytest
 import pytest_asyncio
 
-from simple_sqlite3_orm._orm import AsyncORMBase
 from simple_sqlite3_orm.utils import batched
-from tests.conftest import INDEX_KEYS, INDEX_NAME, TABLE_NAME, TEST_INSERT_BATCH_SIZE
+from tests.conftest import INDEX_KEYS, INDEX_NAME, TEST_INSERT_BATCH_SIZE
+from tests.sample_db.orm import SampleDBAsyncio
 from tests.sample_db.table import SampleTable
 
 logger = logging.getLogger(__name__)
@@ -20,12 +20,6 @@ THREAD_NUM = 2
 # NOTE: the timer interval should not be smaller than 0.01 due to the precision
 #   of asyncio internal clock.
 TIMER_INTERVAL = 0.1
-
-
-class SampleDBAsyncio(AsyncORMBase[SampleTable]):
-    """Test connection pool with async API."""
-
-    _orm_table_name = TABLE_NAME
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -25,9 +25,9 @@ class TestWithSampleDB:
     @pytest.fixture(autouse=True)
     def setup_test(
         self,
-        setup_test_db: SampleDB,
+        setup_test_db_conn: sqlite3.Connection,
     ):
-        self.orm_inst = setup_test_db
+        self.orm_inst = SampleDB(setup_test_db_conn)
 
     def test_create_table(self):
         logger.info("test create table")

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -7,18 +7,12 @@ from typing import Callable
 
 import pytest
 
-from simple_sqlite3_orm._orm import ORMThreadPoolBase
 from simple_sqlite3_orm.utils import batched
-from tests.conftest import INDEX_KEYS, INDEX_NAME, TABLE_NAME, TEST_INSERT_BATCH_SIZE
+from tests.conftest import INDEX_KEYS, INDEX_NAME, TEST_INSERT_BATCH_SIZE
+from tests.sample_db.orm import SampleDBConnectionPool
 from tests.sample_db.table import SampleTable
 
 logger = logging.getLogger(__name__)
-
-
-class SampleDBConnectionPool(ORMThreadPoolBase[SampleTable]):
-    """Test connection pool."""
-
-    _orm_table_name = TABLE_NAME
 
 
 THREAD_NUM = 2


### PR DESCRIPTION
## Introduction

This PR introduces a set of new APIs for further deterministically defining and bootstrapping new database:
1. `orm_bootstrap_table_name`: pre-define the table_name.
2. `orm_bootstrap_create_table_params`: pre-define the table creat statement.
3. `orm_bootstrap_indexes_params`: optional list of statement for creating indexes.

For 2 and 3, we can also provide typeddict of params for generating query statement with table_create_stmt and table_create_index_stmt correspondingly.

With this PR, the previous way to pre-define table_name by setting `_orm_table_name` is deprecated in flavor of `orm_bootstrap_table_name`, `_orm_table_name` now is an internal attr and should not be directly assigned.

Other change:
1. utils: fix check_db_integrity when checking against specific table.
2. test_ci: use SonarSource/sonarqube-scan-action@v4 as the previous one is deprecated by sonarcloud.