### PR TITLE
refactor: ORM: refine the bootstrap API

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -123,7 +123,7 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         con (sqlite3.Connection | ConnectionFactoryType): The sqlite3 connection used by this ORM, or a factory
             function that returns a sqlite3.Connection object on calling.
         table_name (str): The name of the table in the database <con> connected to. This field will take prior over the
-            table_name specified by _orm_table_name attr.
+            table_name specified by orm_bootstrap_table_name attr to allow using different table_name for just one connection.
         schema_name (str): The schema of the table if multiple databases are attached to <con>.
         row_factory (RowFactorySpecifier): The connection scope row_factory to use. Default to "table_sepc".
     """

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -86,7 +86,7 @@ class ORMCommonBase(Generic[TableSpecType]):
 
     orm_bootstrap_table_name: str
     orm_bootstrap_create_table_params: str | CreateTableParams
-    orm_bootstrap_indexes_params: Iterable[str | CreateIndexParams] | None = None
+    orm_bootstrap_indexes_params: list[str | CreateIndexParams]
 
     def __init_subclass__(cls, **kwargs) -> None:
         # check this class' dict to only get the name set during this subclass' creation

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -134,6 +134,8 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         2. orm_bootstrap_create_table_params: the sqlite query to create the table,
             it can be provided as sqlite query, or CreateTableParams for table_create_stmt
             to generate sqlite query from.
+            It not specified, the table create statement will be generated with default configs,
+            See table_spec.table_create_stmt method for more details.
         3. orm_bootstrap_indexes_params: optional, a list of sqlite query or
             CreateIndexParams(for table_create_index_stmt to generate sqlite query from) to
             create indexes from.

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -81,6 +81,8 @@ class ORMCommonBase(Generic[TableSpecType]):
     if not TYPE_CHECKING:
         _orm_table_name: str
         """
+        Used by ORM internally, should not be set directly.
+
         Directly setting this variable is DEPRECATED, use orm_bootstrap_table_name instead.
         """
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -147,11 +147,7 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         """
         _table_name = self.orm_table_name
 
-        try:
-            _table_create_stmt = self.orm_bootstrap_create_table_params
-        except AttributeError:
-            _table_create_stmt = None
-
+        _table_create_stmt = getattr(self, "orm_bootstrap_create_table_params", None)
         if not _table_create_stmt:
             _table_create_stmt = self.orm_table_spec.table_create_stmt(_table_name)
         elif isinstance(_table_create_stmt, dict):
@@ -162,18 +158,15 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         with self._con as conn:
             conn.execute(_table_create_stmt)
 
-        try:
-            if _index_stmts := self.orm_bootstrap_indexes_params:
-                for _index_stmt in _index_stmts:
-                    if isinstance(_index_stmt, dict):
-                        _index_stmt = self.orm_table_spec.table_create_index_stmt(
-                            table_name=_table_name,
-                            **_index_stmt,
-                        )
-                    with self._con as conn:
-                        conn.execute(_index_stmt)
-        except AttributeError:
-            pass
+        if _index_stmts := getattr(self, "orm_bootstrap_indexes_params", None):
+            for _index_stmt in _index_stmts:
+                if isinstance(_index_stmt, dict):
+                    _index_stmt = self.orm_table_spec.table_create_index_stmt(
+                        table_name=_table_name,
+                        **_index_stmt,
+                    )
+                with self._con as conn:
+                    conn.execute(_index_stmt)
 
     def __init__(
         self,

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -170,6 +170,7 @@ class TestORMBase:
                 ),
             ],
         ),
+        ("test_3", None, None),
     ),
 )
 def test_bootstrap(
@@ -180,8 +181,11 @@ def test_bootstrap(
 ):
     class _ORM(SampleDB):
         orm_bootstrap_table_name = table_name
-        orm_bootstrap_create_table_params = create_table_params
-        orm_bootstrap_indexes_params = create_indexes_params
+        if create_table_params:
+            orm_bootstrap_create_table_params = create_table_params
+
+        if create_indexes_params:
+            orm_bootstrap_indexes_params = create_indexes_params
 
     _orm = _ORM(setup_test_db_conn)
     _orm.orm_bootstrap_db()


### PR DESCRIPTION
## Introduction

This PR introduces some refinement over ORM bootstrap db table API:
1. now `orm_bootstrap_create_table_params` becomes optional, orm_bootstrap_db can still be called without this attr. when this attr is not set, the table create stmt will be created by <table_spec>.table_create_stmt with default settings.
2. change `orm_bootstrap_indexes_params`'s typing to `list[str | CreateIndexParams]`.