### PR TITLE
refactor: refine the typing of select/delete_with_returning APIs to better support _row_factory param

### DIFF
--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -10,10 +10,12 @@ from typing_extensions import TypeAlias
 
 from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
 
-RowFactoryType = Callable[[Cursor, Row | tuple[Any, ...] | Any], Any]
+RowFactoryType: TypeAlias = (
+    "Callable[[Cursor, Row | tuple[Any, ...] | Any], Any] | type[sqlite3.Row]"
+)
 """Type hint for callable that can be used as sqlite3 row_factory."""
 
-ConnectionFactoryType = Callable[[], sqlite3.Connection]
+ConnectionFactoryType: TypeAlias = "Callable[[], sqlite3.Connection]"
 
 ColsDefinitionWithDirection: TypeAlias = "tuple[str | tuple[str, ORDER_DIRECTION], ...]"
 ColsDefinition: TypeAlias = "tuple[str, ...]"

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeAlias
 
 from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
 
-RowFactoryType = Callable[[Cursor, Row], Any]
+RowFactoryType = Callable[[Cursor, Row | tuple[Any, ...] | Any], Any]
 """Type hint for callable that can be used as sqlite3 row_factory."""
 
 ConnectionFactoryType = Callable[[], sqlite3.Connection]

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -107,7 +107,8 @@ class TestORMBase:
         assert not setup_connection.orm_check_entry_exist(prim_key=Mystr("not_exist"))
 
     def test_select_entry(self, setup_connection: SampleDB):
-        assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)
+        _selected_row = setup_connection.orm_select_entry(prim_key=mstr)
+        assert entry_for_test == _selected_row
 
     def test_select_entries(self, setup_connection: SampleDB):
         select_result = setup_connection.orm_select_entries(


### PR DESCRIPTION
## Introduction

This PR introduces typing refinements to select/delete_with_returning APIs, now if `_row_factory` param is used, the return type will be typed as the `_row_factory`'s return type.

Other changes:
1. orm: remove `_row_factory` param from `delete_entries` API as not needed. Only `delete_entries_with_returning` will return rows.