### PR TITLE
feat: ORM: expose new property orm_conn_row_factory; allow not changing conn row_factory at ORM init

### DIFF
--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -13,7 +13,6 @@ from typing import (
     Literal,
     TypeVar,
     Union,
-    get_args,
     overload,
 )
 
@@ -38,7 +37,7 @@ P = ParamSpec("P")
 RT = TypeVar("RT")
 
 DoNotChangeRowFactory = Literal["do_not_change"]
-
+DO_NOT_CHANGE_ROW_FACTORY: DoNotChangeRowFactory = "do_not_change"
 
 RowFactorySpecifier = Union[
     RowFactoryType,
@@ -79,9 +78,8 @@ def _select_row_factory(
     if row_factory_specifier == "sqlite3_row_factory":
         return sqlite3.Row
 
-    _do_not_change_literal = get_args(DoNotChangeRowFactory)[0]
-    if row_factory_specifier == _do_not_change_literal:
-        return _do_not_change_literal
+    if row_factory_specifier == DO_NOT_CHANGE_ROW_FACTORY:
+        return DO_NOT_CHANGE_ROW_FACTORY
     raise ValueError(f"invalid specifier: {row_factory_specifier}")
 
 
@@ -207,9 +205,8 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         elif callable(con):
             self._con = con()
 
-        # NOTE: now not changing the connection row_factory is allowed
         _row_factory = _select_row_factory(self.orm_table_spec, row_factory)
-        if _row_factory != get_args(DoNotChangeRowFactory)[0]:
+        if _row_factory != DO_NOT_CHANGE_ROW_FACTORY:
             self._con.row_factory = _row_factory
 
     __class_getitem__ = classmethod(parameterized_class_getitem)

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -202,8 +202,10 @@ class ORMBase(ORMCommonBase[TableSpecType]):
 
         if isinstance(con, sqlite3.Connection):
             self._con = con
-        elif callable(con):
-            self._con = con()
+        elif callable(con) and isinstance(_conn := con(), sqlite3.Connection):
+            self._con = _conn
+        else:
+            raise ValueError(f"invalid {con=}")
 
         _row_factory = _select_row_factory(self.orm_table_spec, row_factory)
         if _row_factory != DO_NOT_CHANGE_ROW_FACTORY:

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -10,10 +10,12 @@ from typing_extensions import TypeAlias
 
 from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
 
-RowFactoryType = Callable[[Cursor, Row | tuple[Any, ...] | Any], Any]
+RowFactoryType: TypeAlias = (
+    "Callable[[Cursor, Row | tuple[Any, ...] | Any], Any] | type[sqlite3.Row]"
+)
 """Type hint for callable that can be used as sqlite3 row_factory."""
 
-ConnectionFactoryType = Callable[[], sqlite3.Connection]
+ConnectionFactoryType: TypeAlias = "Callable[[], sqlite3.Connection]"
 
 ColsDefinitionWithDirection: TypeAlias = "tuple[str | tuple[str, ORDER_DIRECTION], ...]"
 ColsDefinition: TypeAlias = "tuple[str, ...]"

--- a/src/simple_sqlite3_orm/_typing.py
+++ b/src/simple_sqlite3_orm/_typing.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeAlias
 
 from simple_sqlite3_orm._sqlite_spec import ORDER_DIRECTION
 
-RowFactoryType = Callable[[Cursor, Row], Any]
+RowFactoryType = Callable[[Cursor, Row | tuple[Any, ...] | Any], Any]
 """Type hint for callable that can be used as sqlite3 row_factory."""
 
 ConnectionFactoryType = Callable[[], sqlite3.Connection]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import random
 import sqlite3
 import string
 import time
+from pathlib import Path
 from typing import Callable, Generator, get_args
 
 import pytest
@@ -113,6 +114,25 @@ def setup_test_db_conn(
         yield conn
         # finally, do a database integrity check after test operations
         assert utils.check_db_integrity(conn)
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def db_conn_func_scope(
+    tmp_path: Path,
+) -> Generator[sqlite3.Connection]:
+    """Setup a single db connection for a test class."""
+    db_file = tmp_path / "test_db_file.sqlite3"
+
+    conn = sqlite3.connect(db_file)
+    try:
+        # enable optimization
+        utils.enable_wal_mode(conn, relax_sync_mode=True)
+        utils.enable_mmap(conn)
+        utils.enable_tmp_store_at_memory(conn)
+
+        yield conn
     finally:
         conn.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import datetime
 import random
 import sqlite3
@@ -104,8 +105,7 @@ def setup_test_db_conn(
     tmp_path = tmp_path_factory.mktemp("tmp_db_path")
     db_file = tmp_path / "test_db_file.sqlite3"
 
-    conn = sqlite3.connect(db_file)
-    try:
+    with contextlib.closing(sqlite3.connect(db_file)) as conn:
         # enable optimization
         utils.enable_wal_mode(conn, relax_sync_mode=True)
         utils.enable_mmap(conn)
@@ -114,8 +114,6 @@ def setup_test_db_conn(
         yield conn
         # finally, do a database integrity check after test operations
         assert utils.check_db_integrity(conn)
-    finally:
-        conn.close()
 
 
 @pytest.fixture
@@ -125,16 +123,13 @@ def db_conn_func_scope(
     """Setup a single db connection for a test class."""
     db_file = tmp_path / "test_db_file.sqlite3"
 
-    conn = sqlite3.connect(db_file)
-    try:
+    with contextlib.closing(sqlite3.connect(db_file)) as conn:
         # enable optimization
         utils.enable_wal_mode(conn, relax_sync_mode=True)
         utils.enable_mmap(conn)
         utils.enable_tmp_store_at_memory(conn)
 
         yield conn
-    finally:
-        conn.close()
 
 
 DB_LOCK_WAIT_TIMEOUT = 30

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -107,7 +107,8 @@ class TestORMBase:
         assert not setup_connection.orm_check_entry_exist(prim_key=Mystr("not_exist"))
 
     def test_select_entry(self, setup_connection: SampleDB):
-        assert entry_for_test == setup_connection.orm_select_entry(prim_key=mstr)
+        _selected_row = setup_connection.orm_select_entry(prim_key=mstr)
+        assert entry_for_test == _selected_row
 
     def test_select_entries(self, setup_connection: SampleDB):
         select_result = setup_connection.orm_select_entries(


### PR DESCRIPTION
## Introduction

This PR introduces the following changes to ORM related to connection row_factory:
1. expose new property `orm_conn_row_factory`, which gets and sets the `sqlite3.Connection` instance embedded in the ORM instance.
2. add new row_factory specifier `do_not_change`, now at ORM instance init, we can choose to not change the connection's row_factory.
3. for ORM init, `row_factory = None` now means clearing any previously set row_factory for the current connection. However, the meaning of `row_factory = None` in each APIs call still remains the same as not changing the row_factory for cursor in this method call.

Other minor changes:
1. typing: add `sqlite3.Row` into RowFactoryType.
2. orm: minor docstrings update.
3. orm: `__init__`: refine how `con` param provided as connection_factory is handled.