### PR TITLE
feat: TableSpec: add UPDATE query composer API table_update_stmt

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -439,7 +439,7 @@ class TableSpec(BaseModel):
         else:
             _gen_or_option_stmt = ""
 
-        gen_update_stmt = f"UPDATE {_gen_or_option_stmt} INTO {update_target}"
+        gen_update_stmt = f"UPDATE {_gen_or_option_stmt} {update_target}"
 
         cls.table_check_cols(set_cols)
         _cols_named_placeholder = (f"{_col} = :{_col}" for _col in set_cols)

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -60,7 +60,7 @@ class TableSpec(BaseModel):
             return where_stmt
         if where_cols:
             cls.table_check_cols(where_cols)
-            _conditions = (f"{_col}=:{_col}" for _col in where_cols)
+            _conditions = (f"{_col} = :{_col}" for _col in where_cols)
             _where_cols_stmt = " AND ".join(_conditions)
             return f"WHERE {_where_cols_stmt}"
         return ""
@@ -439,11 +439,13 @@ class TableSpec(BaseModel):
         else:
             _gen_or_option_stmt = ""
 
-        gen_update_stmt = f"UPDATE {_gen_or_option_stmt} {update_target}"
+        gen_update_stmt = gen_sql_stmt(
+            "UPDATE", _gen_or_option_stmt, update_target, end_with=None
+        )
 
         cls.table_check_cols(set_cols)
         _cols_named_placeholder = (f"{_col} = :{_col}" for _col in set_cols)
-        gen_set_stmt = f"SET ({','.join(_cols_named_placeholder)})"
+        gen_set_stmt = f"SET {', '.join(_cols_named_placeholder)}"
 
         gen_where_stmt = cls._generate_where_stmt(where_cols, where_stmt)
         gen_returning_stmt = cls._generate_returning_stmt(

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -412,24 +412,26 @@ class TableSpec(BaseModel):
         Check https://www.sqlite.org/lang_update.html for more details.
 
         NOTE that UPDATE-FROM extension is currently not supported by this method.
+        NOTE that UPDATE-WITH-LIMIT is an optional feature, needs to be enabled at compiled time with
+            SQLITE_ENABLE_UPDATE_DELETE_LIMIT.
 
         Args:
             or_option (INSERT_OR | None, optional): The fallback operation if update failed. Defaults to None.
-            update_target (str): The name of table insert into.
+            update_target (str): The name of table to update.
             set_cols (tuple[str, ...]): The cols to be updated.
             where_cols (tuple[str, ...] | None, optional): A list of cols to be compared in where
                 statement. Defaults to None.
             where_stmt (str | None, optional): The full where statement string, this
                 precedes the <where_cols> param if set. Defaults to None.
-            returning_cols (tuple[str, ...] | Literal["*"] | None): Which cols are included in the returned entries.
-                Defaults to None.
+            returning_cols (tuple[str, ...] | Literal["*"] | None): If specified, enable RETURNING stmt, and specifying Which cols
+                included in the returned entries. Defaults to None.
             returning_stmt (str | None, optional): The full returning statement string, this
                 precedes the <returning_cols> param. Defaults to None.
             order_by (Iterable[str  |  tuple[str, ORDER_DIRECTION], ...] | None, optional):
-                A list of cols for ordering result. Defaults to None.
+                Works with LIMIT, to specify the range that LIMIT affects. Defaults to None.
             order_by_stmt (str | None, optional): The order_by statement string, this
                 precedes the <order_by> param if set. Defaults to None.
-            limit (int | None, optional): Limit the number of result entries. Defaults to None.
+            limit (int | None, optional): Limit the number of affected entries. Defaults to None.
 
         Returns:
             str: The generated update sqlite3 query.

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -190,7 +190,7 @@ class ConstrainRepr:
         return hash(self.constraints)
 
 
-def gen_sql_stmt(*components: str) -> str:
+def gen_sql_stmt(*components: str, end_with: str | None = ";") -> str:
     """Combine each components into a single sql stmt."""
     with StringIO() as buffer:
         for comp in components:
@@ -198,5 +198,6 @@ def gen_sql_stmt(*components: str) -> str:
                 continue
             buffer.write(" ")
             buffer.write(comp)
-        buffer.write(";")
+        if end_with:
+            buffer.write(end_with)
         return buffer.getvalue().strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,19 @@ from tests.sample_db.table import (
 # for reproducible test
 random.seed(0)
 
+# sqlite3 lib features set
+
+
+class SQLITE3_COMPILE_OPTION_FLAGS:
+    with contextlib.closing(sqlite3.connect(":memory:")) as conn:
+        RETURNING_AVAILABLE = sqlite3.sqlite_version_info >= (3, 35, 0)
+        SQLITE_ENABLE_UPDATE_DELETE_LIMIT = bool(
+            utils.check_pragma_compile_time_options(
+                conn, "SQLITE_ENABLE_UPDATE_DELETE_LIMIT"
+            )
+        )
+
+
 # test config
 
 TEST_ENTRY_NUM = 120_000

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import contextlib
 import sqlite3
 from collections.abc import Mapping
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, TypedDict
 
 import pytest
 from typing_extensions import Annotated
 
 from simple_sqlite3_orm import ConstrainRepr, CreateTableParams, TableSpec
+from tests.conftest import SQLITE3_COMPILE_OPTION_FLAGS
 
 
 class SimpleTableForTest(TableSpec):
@@ -23,6 +24,12 @@ class SimpleTableForTest(TableSpec):
     ]
 
     extra: Optional[float] = None
+
+
+class SimpleTableForTestCols(TypedDict, total=False):
+    id: int
+    id_str: str
+    extra: float
 
 
 TBL_NAME = "test_table"
@@ -53,7 +60,11 @@ def test_table_create(table_create_params: CreateTableParams) -> None:
 
 
 class TestTableSpecWithDB:
-    """A quick and simple test to test through normal usage of tablespec"""
+    """A quick and simple test to test through normal usage of tablespec.
+
+    NOTE that this test is mostly focusing on syntax, i.e., to ensure that the generated
+        sqlite3 query can be parsed and accepted by sqlite3 DB engine.
+    """
 
     ENTRY_FOR_TEST = SimpleTableForTest(id=123, id_str="123", extra=0.123)
 
@@ -93,6 +104,120 @@ class TestTableSpecWithDB:
             assert len(res) == 1
             assert isinstance(res[0], SimpleTableForTest)
             assert res[0] == _to_lookup
+
+    #
+    # ------ UPDATE sqlite3 stmt test ------ #
+    #
+
+    UPDATE_API_TEST_CASES = [
+        (
+            _set_values := SimpleTableForTestCols(id_str="1.23456"),
+            SimpleTableForTest.table_update_stmt(
+                update_target=TBL_NAME,
+                set_cols=tuple(_set_values),
+                where_cols=("id",),
+            ),
+            ENTRY_FOR_TEST.model_copy(update=_set_values),
+        ),
+    ]
+
+    if SQLITE3_COMPILE_OPTION_FLAGS.SQLITE_ENABLE_UPDATE_DELETE_LIMIT:
+        UPDATE_API_TEST_CASES.extend(
+            [
+                (
+                    _set_values := SimpleTableForTestCols(
+                        id_str="2.3456", extra=2.3456
+                    ),
+                    SimpleTableForTest.table_update_stmt(
+                        update_target=TBL_NAME,
+                        set_cols=tuple(_set_values),
+                        where_cols=("id",),
+                        order_by=("id",),
+                        limit=1,
+                    ),
+                    ENTRY_FOR_TEST.model_copy(update=_set_values),
+                ),
+                (
+                    _set_values := SimpleTableForTestCols(
+                        id_str="2.3456", extra=2.3456
+                    ),
+                    SimpleTableForTest.table_update_stmt(
+                        or_option="fail",
+                        update_target=TBL_NAME,
+                        set_cols=tuple(_set_values),
+                        where_cols=("id",),
+                        order_by=("id",),
+                        limit=1,
+                    ),
+                    ENTRY_FOR_TEST.model_copy(update=_set_values),
+                ),
+            ]
+        )
+
+        if SQLITE3_COMPILE_OPTION_FLAGS.RETURNING_AVAILABLE:
+            UPDATE_API_TEST_CASES.append(
+                (
+                    _set_values := SimpleTableForTestCols(
+                        id_str="2.3456", extra=2.3456
+                    ),
+                    SimpleTableForTest.table_update_stmt(
+                        or_option="fail",
+                        update_target=TBL_NAME,
+                        set_cols=tuple(_set_values),
+                        where_cols=("id",),
+                        returning_cols="*",
+                        order_by=("id",),
+                        limit=1,
+                    ),
+                    ENTRY_FOR_TEST.model_copy(update=_set_values),
+                )
+            )
+
+    if SQLITE3_COMPILE_OPTION_FLAGS.RETURNING_AVAILABLE:
+        UPDATE_API_TEST_CASES.append(
+            (
+                _set_values := SimpleTableForTestCols(id_str="2.3456", extra=2.3456),
+                SimpleTableForTest.table_update_stmt(
+                    or_option="fail",
+                    update_target=TBL_NAME,
+                    set_cols=tuple(_set_values),
+                    where_cols=("id",),
+                    returning_cols="*",
+                ),
+                ENTRY_FOR_TEST.model_copy(update=_set_values),
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "set_values, update_stmt, expected_result", UPDATE_API_TEST_CASES
+    )
+    def test_update_entry(
+        self,
+        db_conn: sqlite3.Connection,
+        set_values: Mapping[str, Any],
+        update_stmt: str,
+        expected_result: SimpleTableForTest,
+        prepare_test_entry,
+    ):
+        to_update = self.ENTRY_FOR_TEST
+
+        _params = SimpleTableForTestCols(id=to_update.id, **set_values)
+        with db_conn as _conn:
+            _conn.execute(update_stmt, _params)
+
+        with db_conn as _conn:
+            _cur = _conn.execute(
+                SimpleTableForTest.table_select_stmt(
+                    select_from=TBL_NAME, where_cols=("id",)
+                ),
+                {"id": to_update.id},
+            )
+            _cur.row_factory = SimpleTableForTest.table_row_factory
+
+            res = _cur.fetchone()
+            assert res == expected_result
+
+    # ------ end of UPDATE sqlite3 stmt test ------ #
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Introduction

>[!NOTE]
> This is the first PR to introduce UPDATE support for simple-sqlite3-orm, which adds UPDATE query compose API to TableSpec.

This PR introduces UPDATE query compose support to TableSpec, as the initial step to support UPDATE operation.

Other changes:
1. tests: now before test we will check the sqlite3 lib's compilation option(`SQLITE_ENABLE_UPDATE_DELETE_LIMIT`) and sqlite3 lib version(RETURNING is supported since 3.35.0), and store the flags in `SQLITE3_COMPILE_OPTION_FLAGS`, so that we can skip corresponding tests when some flags are not available.
2. tests: use a new way to arrange test for sqlite3 query composer, currently only UPDATE composer is using the new way. Will refactor the tests for INSERT, SELECT and DELETE composer later.