### PR TITLE
refactor: TableSpec: UPDATE stmt compose: handle the case of cols overlapping in SET stmt and WHERE stmt

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -485,15 +485,16 @@ class TableSpec(BaseModel):
         )
         return res
 
+    @classmethod
     def table_preprare_update_where_cols(
-        self, where_cols: Mapping[str, Any]
+        cls, where_cols: Mapping[str, Any]
     ) -> Mapping[str, Any]:
         """Regulate the <where_cols> so that it will not overlap with <set_cols>.
 
         This is MUST for directly using the sqlite query stmt generated from table_update_stmt.
         """
         return {
-            f"{self._table_update_where_cols_prefix}{k}": v
+            f"{cls._table_update_where_cols_prefix}{k}": v
             for k, v in where_cols.items()
         }
 

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -391,7 +391,9 @@ class TableSpec(BaseModel):
         )
         return res
 
-    _table_update_where_cols_prefix = "__table_spec_"
+    _table_update_where_cols_prefix: ClassVar[Literal["__table_spec_"]] = (
+        "__table_spec_"
+    )
 
     @classmethod
     @lru_cache

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -415,10 +415,11 @@ class TableSpec(BaseModel):
 
         Check https://www.sqlite.org/lang_update.html for more details.
 
-        NOTE: to avoid overlapping between <set_cols> and <where_cols>, this method
-            will prefix cols name with <_table_spec_update_where_cols_prefix> when generating
+        NOTE: to avoid overlapping between <set_cols> and <where_cols> when generating named-placeholders,
+            this method will prefix cols name with <_table_spec_update_where_cols_prefix> when generating
             WHERE statement.
-            To directly use the stmt generated from this API when where
+            To directly use the stmt generated from this API, dev must use table_preprare_update_where_cols
+            to prepare the col/value mapping for params.
 
         NOTE that UPDATE-FROM extension is currently not supported by this method.
         NOTE that UPDATE-WITH-LIMIT is an optional feature, needs to be enabled at compiled time with

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -120,6 +120,25 @@ class TestTableSpecWithDB:
             ),
             ENTRY_FOR_TEST.model_copy(update=_set_values),
         ),
+        (
+            _set_values := SimpleTableForTestCols(id=678, id_str="1.23456"),
+            _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
+            SimpleTableForTest.table_update_stmt(
+                update_target=TBL_NAME,
+                set_cols=tuple(_set_values),
+                where_stmt=f"WHERE id = {ENTRY_FOR_TEST.id}",
+            ),
+            ENTRY_FOR_TEST.model_copy(update=_set_values),
+        ),
+        (
+            _set_values := SimpleTableForTestCols(id=678, id_str="1.23456"),
+            _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
+            SimpleTableForTest.table_update_stmt(
+                update_target=TBL_NAME,
+                set_cols=tuple(_set_values),
+            ),
+            ENTRY_FOR_TEST.model_copy(update=_set_values),
+        ),
     ]
 
     if SQLITE3_COMPILE_OPTION_FLAGS.SQLITE_ENABLE_UPDATE_DELETE_LIMIT:

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -66,7 +66,7 @@ class TestTableSpecWithDB:
         sqlite3 query can be parsed and accepted by sqlite3 DB engine.
     """
 
-    ENTRY_FOR_TEST = SimpleTableForTest(id=123, id_str="123", extra=0.123)
+    ENTRY_FOR_TEST = ENTRY_FOR_TEST
 
     @pytest.fixture
     def db_conn(self):
@@ -112,10 +112,11 @@ class TestTableSpecWithDB:
     UPDATE_API_TEST_CASES = [
         (
             _set_values := SimpleTableForTestCols(id=678, id_str="1.23456"),
+            _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
             SimpleTableForTest.table_update_stmt(
                 update_target=TBL_NAME,
                 set_cols=tuple(_set_values),
-                where_cols=("id",),
+                where_cols=tuple(_where_cols),
             ),
             ENTRY_FOR_TEST.model_copy(update=_set_values),
         ),
@@ -128,10 +129,11 @@ class TestTableSpecWithDB:
                     _set_values := SimpleTableForTestCols(
                         id=678, id_str="2.3456", extra=2.3456
                     ),
+                    _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
                     SimpleTableForTest.table_update_stmt(
                         update_target=TBL_NAME,
                         set_cols=tuple(_set_values),
-                        where_cols=("id",),
+                        where_cols=tuple(_where_cols),
                         order_by=("id",),
                         limit=1,
                     ),
@@ -141,11 +143,12 @@ class TestTableSpecWithDB:
                     _set_values := SimpleTableForTestCols(
                         id=678, id_str="2.3456", extra=2.3456
                     ),
+                    _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
                     SimpleTableForTest.table_update_stmt(
                         or_option="fail",
                         update_target=TBL_NAME,
                         set_cols=tuple(_set_values),
-                        where_cols=("id",),
+                        where_cols=tuple(_where_cols),
                         order_by=("id",),
                         limit=1,
                     ),
@@ -160,11 +163,12 @@ class TestTableSpecWithDB:
                     _set_values := SimpleTableForTestCols(
                         id=678, id_str="2.3456", extra=2.3456
                     ),
+                    _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
                     SimpleTableForTest.table_update_stmt(
                         or_option="fail",
                         update_target=TBL_NAME,
                         set_cols=tuple(_set_values),
-                        where_cols=("id",),
+                        where_cols=tuple(_where_cols),
                         returning_cols="*",
                         order_by=("id",),
                         limit=1,
@@ -177,11 +181,12 @@ class TestTableSpecWithDB:
         UPDATE_API_TEST_CASES.append(
             (
                 _set_values := SimpleTableForTestCols(id_str="2.3456", extra=2.3456),
+                _where_cols := ENTRY_FOR_TEST.table_dump_asdict(),
                 SimpleTableForTest.table_update_stmt(
                     or_option="fail",
                     update_target=TBL_NAME,
                     set_cols=tuple(_set_values),
-                    where_cols=("id",),
+                    where_cols=tuple(_where_cols),
                     returning_cols="*",
                 ),
                 ENTRY_FOR_TEST.model_copy(update=_set_values),
@@ -189,31 +194,28 @@ class TestTableSpecWithDB:
         )
 
     @pytest.mark.parametrize(
-        "set_values, update_stmt, expected_result", UPDATE_API_TEST_CASES
+        "set_values, where_cols, update_stmt, expected_result", UPDATE_API_TEST_CASES
     )
     def test_update_entry(
         self,
         db_conn: sqlite3.Connection,
         set_values: Mapping[str, Any],
+        where_cols: Mapping[str, Any],
         update_stmt: str,
         expected_result: SimpleTableForTest,
         prepare_test_entry,
     ):
-        to_update = self.ENTRY_FOR_TEST
-
         _params = SimpleTableForTestCols(
-            id=to_update.id,
-            **SimpleTableForTest.table_preprare_update_where_cols(set_values),
+            **SimpleTableForTest.table_preprare_update_where_cols(where_cols),
+            **set_values,
         )
         with db_conn as _conn:
             _conn.execute(update_stmt, _params)
 
+        # NOTE: we only have one entry at the table
         with db_conn as _conn:
             _cur = _conn.execute(
-                SimpleTableForTest.table_select_stmt(
-                    select_from=TBL_NAME, where_cols=("id",)
-                ),
-                {"id": to_update.id},
+                SimpleTableForTest.table_select_stmt(select_from=TBL_NAME)
             )
             _cur.row_factory = SimpleTableForTest.table_row_factory
 

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -111,7 +111,7 @@ class TestTableSpecWithDB:
 
     UPDATE_API_TEST_CASES = [
         (
-            _set_values := SimpleTableForTestCols(id_str="1.23456"),
+            _set_values := SimpleTableForTestCols(id=678, id_str="1.23456"),
             SimpleTableForTest.table_update_stmt(
                 update_target=TBL_NAME,
                 set_cols=tuple(_set_values),
@@ -126,7 +126,7 @@ class TestTableSpecWithDB:
             [
                 (
                     _set_values := SimpleTableForTestCols(
-                        id_str="2.3456", extra=2.3456
+                        id=678, id_str="2.3456", extra=2.3456
                     ),
                     SimpleTableForTest.table_update_stmt(
                         update_target=TBL_NAME,
@@ -139,7 +139,7 @@ class TestTableSpecWithDB:
                 ),
                 (
                     _set_values := SimpleTableForTestCols(
-                        id_str="2.3456", extra=2.3456
+                        id=678, id_str="2.3456", extra=2.3456
                     ),
                     SimpleTableForTest.table_update_stmt(
                         or_option="fail",
@@ -158,7 +158,7 @@ class TestTableSpecWithDB:
             UPDATE_API_TEST_CASES.append(
                 (
                     _set_values := SimpleTableForTestCols(
-                        id_str="2.3456", extra=2.3456
+                        id=678, id_str="2.3456", extra=2.3456
                     ),
                     SimpleTableForTest.table_update_stmt(
                         or_option="fail",
@@ -201,7 +201,10 @@ class TestTableSpecWithDB:
     ):
         to_update = self.ENTRY_FOR_TEST
 
-        _params = SimpleTableForTestCols(id=to_update.id, **set_values)
+        _params = SimpleTableForTestCols(
+            id=to_update.id,
+            **SimpleTableForTest.table_preprare_update_where_cols(set_values),
+        )
         with db_conn as _conn:
             _conn.execute(update_stmt, _params)
 


### PR DESCRIPTION
## Introduction

In statement composing, simple-sqlite3-orm will use named-placeholder for cols value specifying, and the placeholder name is the same as corresponding cols. But this will become a problem in UPDATE stmt composing, as we will specify col/value pairs in both SET stmt and WHERE stmt, casuing named-placeholder overlapping.

This PR fixes the above case, now for named-placeholder in WHERE stmt, the placeholder will be named with origin col name prefixed with literal str "__table_spec_".

Correspondingly, `table_preprare_update_where_cols` is provided to pre-process the col/values mapping for query params when developer wants to directly use UPDATE query composed by `table_update_stmt` API. 