### PR TITLE
fix: table_spec: fix insert query composing doesn't include cols definition

### DIFF
--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -375,7 +375,11 @@ class TableSpec(BaseModel):
             cls.table_check_cols(insert_cols)
 
             _cols_named_placeholder = (f":{_col}" for _col in insert_cols)
-            gen_insert_value_stmt = f"VALUES ({','.join(_cols_named_placeholder)})"
+            gen_insert_value_stmt = gen_sql_stmt(
+                f"({','.join(insert_cols)})",
+                "VALUES",
+                f"({','.join(_cols_named_placeholder)})",
+            )
         else:
             _cols_named_placeholder = (f":{_col}" for _col in cls.table_columns)
             gen_insert_value_stmt = f"VALUES ({','.join(_cols_named_placeholder)}) "

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -374,9 +374,9 @@ class TableSpec(BaseModel):
         else:
             if insert_cols:
                 _cols = insert_cols
+                cls.table_check_cols(_cols)
             else:
                 _cols = tuple(cls.table_columns)
-            cls.table_check_cols(_cols)
 
             _cols_named_placeholder = (f":{_col}" for _col in _cols)
             gen_insert_cols_specify_stmt = gen_sql_stmt(

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -370,19 +370,21 @@ class TableSpec(BaseModel):
         gen_insert_stmt = f"INSERT {_gen_or_option_stmt} INTO {insert_into}"
 
         if insert_default:
-            gen_insert_value_stmt = "DEFAULT VALUES"
-        elif insert_cols:
-            cls.table_check_cols(insert_cols)
+            gen_insert_cols_specify_stmt = "DEFAULT VALUES"
+        else:
+            if insert_cols:
+                _cols = insert_cols
+            else:
+                _cols = tuple(cls.table_columns)
+            cls.table_check_cols(_cols)
 
-            _cols_named_placeholder = (f":{_col}" for _col in insert_cols)
-            gen_insert_value_stmt = gen_sql_stmt(
-                f"({','.join(insert_cols)})",
+            _cols_named_placeholder = (f":{_col}" for _col in _cols)
+            gen_insert_cols_specify_stmt = gen_sql_stmt(
+                f"({','.join(_cols)})",
                 "VALUES",
                 f"({','.join(_cols_named_placeholder)})",
+                end_with=None,
             )
-        else:
-            _cols_named_placeholder = (f":{_col}" for _col in cls.table_columns)
-            gen_insert_value_stmt = f"VALUES ({','.join(_cols_named_placeholder)}) "
 
         gen_returning_stmt = cls._generate_returning_stmt(
             returning_cols, returning_stmt
@@ -390,7 +392,7 @@ class TableSpec(BaseModel):
 
         res = gen_sql_stmt(
             gen_insert_stmt,
-            gen_insert_value_stmt,
+            gen_insert_cols_specify_stmt,
             gen_returning_stmt,
         )
         return res

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -8,8 +8,10 @@ from typing import Any, Iterable, Optional, TypedDict
 import pytest
 from typing_extensions import Annotated
 
-from simple_sqlite3_orm import ConstrainRepr, CreateTableParams, TableSpec
+from simple_sqlite3_orm import ConstrainRepr, CreateTableParams, TableSpec, utils
 from tests.conftest import SQLITE3_COMPILE_OPTION_FLAGS
+
+ID_STR_DEFAULT_VALUE = "aabbcc"
 
 
 class SimpleTableForTest(TableSpec):
@@ -20,7 +22,7 @@ class SimpleTableForTest(TableSpec):
 
     id_str: Annotated[
         str,
-        ConstrainRepr("NOT NULL"),
+        ConstrainRepr("NOT NULL", ("DEFAULT", utils.wrap_value(ID_STR_DEFAULT_VALUE))),
     ]
 
     extra: Optional[float] = None
@@ -119,6 +121,21 @@ class TestTableSpecWithDB:
 
             _res: SimpleTableForTest = _cur.fetchone()
             assert all(v == getattr(_res, k) for k, v in to_insert.items())
+
+    def test_insert_default_values(self, db_conn: sqlite3.Connection):
+        table_insert_stmt = SimpleTableForTest.table_insert_stmt(
+            insert_into=TBL_NAME, insert_default=True
+        )
+        with db_conn as _conn:
+            _conn.execute(table_insert_stmt)
+
+        with db_conn as _conn:
+            _cur = _conn.execute(
+                SimpleTableForTest.table_select_stmt(select_from=TBL_NAME)
+            )
+            # for cols with no defautl value defined, NULL will be assigned
+            # for rowid, it will be automatically incremented
+            assert _cur.fetchone() == (1, ID_STR_DEFAULT_VALUE, None)
 
     def test_lookup_entry(self, db_conn: sqlite3.Connection, prepare_test_entry):
         _to_lookup = self.ENTRY_FOR_TEST

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -85,11 +85,40 @@ class TestTableSpecWithDB:
         with db_conn as _conn:
             _conn.execute(table_insert_stmt, _to_insert.table_dump_asdict())
 
-    def test_insert_entry(self, db_conn: sqlite3.Connection):
-        _to_insert = self.ENTRY_FOR_TEST
-        table_insert_stmt = SimpleTableForTest.table_insert_stmt(insert_into=TBL_NAME)
+    @pytest.mark.parametrize(
+        "case, to_insert",
+        (
+            (
+                "insert a complete row",
+                (SimpleTableForTestCols(id=1, id_str="1", extra=0.123)),
+            ),
+            (
+                "insert a partially set row, omit id(rowid alias)",
+                (SimpleTableForTestCols(id_str="1", extra=0.123)),
+            ),
+            (
+                "insert a row with order shuffled",
+                (SimpleTableForTestCols(extra=0.123, id=1, id_str="1")),
+            ),
+        ),
+    )
+    def test_insert_entry(
+        self, case, to_insert: SimpleTableForTestCols, db_conn: sqlite3.Connection
+    ):
+        table_insert_stmt = SimpleTableForTest.table_insert_stmt(
+            insert_into=TBL_NAME, insert_cols=tuple(to_insert)
+        )
         with db_conn as _conn:
-            _conn.execute(table_insert_stmt, _to_insert.table_dump_asdict())
+            _conn.execute(table_insert_stmt, to_insert)
+
+        with db_conn as _conn:
+            _cur = _conn.execute(
+                SimpleTableForTest.table_select_stmt(select_from=TBL_NAME)
+            )
+            _cur.row_factory = SimpleTableForTest.table_row_factory
+
+            _res: SimpleTableForTest = _cur.fetchone()
+            assert all(v == getattr(_res, k) for k, v in to_insert.items())
 
     def test_lookup_entry(self, db_conn: sqlite3.Connection, prepare_test_entry):
         _to_lookup = self.ENTRY_FOR_TEST


### PR DESCRIPTION
## Introduction

Previously, when generating insert query, the statement of specifying which cols will be assigned are not included, but only the values to insert are specified. 

This will not cause problem when we do insert with row that has all cols assigned, and with the same schema as table, but will cause problem when we insert with row that cols order dosen't match schema, or cols are partially set(like without specifying `rowid`).

This PR fixes the above issue, and add tests to cover the above cases.