### PR TITLE
feat: ORM: add `orm_update_entries_many` API, an executemany version of `orm_update_entries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,9 @@ for entry in res_gen:
 
 ### Update rows
 
-You can update specific rows as follow:
+You can update specific rows with one set of params as follow:
 
 ```python
-
 # specify rows by matching cols
 #   WHERE stmt will be generated from `where_cols_value`.
 orm.orm_update_entries(
@@ -177,6 +176,22 @@ orm.orm_update_entries(
     set_values=MyTableCols(entry_token="ccddee123", entry_type="C"),
     where_stmt="WHERE entry_id > :entry_lower_bound AND entry_id < :entry_upper_bound",
     _extra_params={"entry_lower_bound": 123, "entry_upper_bound": 456}
+)
+```
+
+Also, there is an `executemany` version of ORM update API, `orm_update_entries_many`, which you can use many sets of params for the same UPDATE query execution.
+
+Using this API is **SIGNIFICANTLY** faster with lower memory usage than calling `orm_update_entries` each time in a for loop.
+
+```python
+set_cols_value_iter: Iterable[MyTableCols]
+where_cols_value_iter: Iterable[Mapping[str, Any]]
+
+updated_rows_count: int = orm.orm_update_entries_many(
+    set_cols=("entry_id", "entry_token", "entry_type"),
+    where_cols=("entry_id",),
+    set_cols_value=set_cols_value_iter,
+    where_cols_value=where_cols_value_iter,
 )
 ```
 

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -778,6 +778,9 @@ class ORMBase(ORMCommonBase[TableSpecType]):
     ) -> int:
         """UPDATE specific entries by matching <where_cols_value>.
 
+        NOTE: if you want to using the same query stmt with different set of params(set col/values and/or where col/values),
+            it is highly recommended to use `orm_update_entries_many` API, it will be significantly faster to call `orm_update_entries`
+            in a for loop(in my test with 2000 entries, using `orm_update_entries_many` is around 300 times faster).
         NOTE: currently UPDATE-WITH-LIMIT and RETURNING are not supported by this method.
 
         Args:

--- a/src/simple_sqlite3_orm/_orm/_base.py
+++ b/src/simple_sqlite3_orm/_orm/_base.py
@@ -894,6 +894,9 @@ class ORMBase(ORMCommonBase[TableSpecType]):
         Params like `set_cols_value` and `where_cols_value` need to be provided as iterables.
         NOTE that the execution will end and return when any of the input iterable exhausted.
 
+        NOTE that `_extra_params` and `_extra_params_iter` will not be serialized. Caller needs to
+            provide the serialized mappings ready for `executemany`.
+
         Args:
             set_cols (tuple[str, ...]): Cols to be updated.
             set_cols_value (Iterable[Mapping[str, Any]]): An iterable of values of to-be-updated cols.

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any, ClassVar, Iterable, Literal, TypedDict, TypeVar
+from typing import Any, ClassVar, Generator, Iterable, Literal, TypedDict, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -769,6 +769,14 @@ class TableSpec(BaseModel):
             return {}
         _inst = cls.model_construct(**_in)
         return _inst.model_dump(exclude_unset=True)
+
+    @classmethod
+    def table_serialize_mappings(
+        cls, _iter: Iterable[Mapping[str, Any]]
+    ) -> Generator[dict[str, Any]]:
+        """Convert an iter of Mappings into an generator of serialized dict."""
+        for _entry in _iter:
+            yield cls.table_serialize_mapping(_entry)
 
     @classmethod
     def table_deserialize_asdict_row_factory(

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -773,7 +773,7 @@ class TableSpec(BaseModel):
     @classmethod
     def table_serialize_mappings(
         cls, _iter: Iterable[Mapping[str, Any]]
-    ) -> Generator[dict[str, Any]]:
+    ) -> Generator[dict[str, Any]]:  # pragma: no cover
         """Convert an iter of Mappings into an generator of serialized dict."""
         for _entry in _iter:
             yield cls.table_serialize_mapping(_entry)

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -307,7 +307,7 @@ class TestORMBase:
         )
 
 
-TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT = 2_000
+TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT = 20_000
 
 
 class TestORMUpdateEntriesMany:
@@ -403,7 +403,6 @@ class TestORMUpdateEntriesMany:
                 where_stmt="WHERE id = :check_id",
             ),
         )
-        self._check_result(_setup_orm)
 
         _check_set = set(range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT))
         for row in _setup_orm.orm_select_entries():

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -330,16 +330,16 @@ class TestORMUpdateEntriesMany:
     def _check_result(self, _setup_orm: SimpleTableORM):
         _check_set = set(range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT))
         for row in _setup_orm.orm_select_entries():
-            assert row.id == row.extra
+            assert row.id == row.int_str
             _check_set.discard(row.id)
         assert not _check_set
 
     def test_with_where_cols(self, _setup_orm: SimpleTableORM):
         _setup_orm.orm_update_entries_many(
-            set_cols=("extra",),
+            set_cols=("int_str",),
             where_cols=("id",),
             set_cols_value=(
-                SimpleTableForTestCols(extra=i)
+                SimpleTableForTestCols(int_str=i)
                 for i in range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT)
             ),
             where_cols_value=(
@@ -353,10 +353,10 @@ class TestORMUpdateEntriesMany:
         self, _setup_orm: SimpleTableORM
     ):
         _setup_orm.orm_update_entries_many(
-            set_cols=("extra",),
+            set_cols=("int_str",),
             where_stmt="WHERE id = :check_id",
             set_cols_value=(
-                SimpleTableForTestCols(extra=i)
+                SimpleTableForTestCols(int_str=i)
                 for i in range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT)
             ),
             _extra_params_iter=(
@@ -372,10 +372,10 @@ class TestORMUpdateEntriesMany:
 
         _setup_orm.orm_update_entries_many(
             or_option="replace",
-            set_cols=("extra",),
+            set_cols=("int_str",),
             where_stmt="WHERE id = :check_id",
             set_cols_value=repeat(
-                SimpleTableForTestCols(extra=update_value), times=repeat_times
+                SimpleTableForTestCols(int_str=update_value), times=repeat_times
             ),
             _extra_params={"check_id": entry_to_update_id},
         )
@@ -383,7 +383,7 @@ class TestORMUpdateEntriesMany:
         check_entry = _setup_orm.orm_select_entry(
             SimpleTableForTestCols(id=entry_to_update_id)
         )
-        assert check_entry.extra == update_value
+        assert check_entry.int_str == update_value
 
     def test_with_custom_stmt(self, _setup_orm: SimpleTableORM):
         offset = 1000000
@@ -391,7 +391,7 @@ class TestORMUpdateEntriesMany:
         def _preapre_params():
             for i in range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT):
                 yield dict(
-                    **SimpleTableForTestCols(id=i + offset, extra=i + offset),
+                    **SimpleTableForTestCols(id=i + offset, int_str=i + offset),
                     check_id=i,
                 )
 
@@ -399,14 +399,14 @@ class TestORMUpdateEntriesMany:
             _extra_params_iter=_preapre_params(),
             _stmt=_setup_orm.orm_table_spec.table_update_stmt(
                 update_target=_setup_orm.orm_table_name,
-                set_cols=("extra", "id"),
+                set_cols=("int_str", "id"),
                 where_stmt="WHERE id = :check_id",
             ),
         )
 
         _check_set = set(range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT))
         for row in _setup_orm.orm_select_entries():
-            assert row.id == row.extra
+            assert row.id == row.int_str
             _check_set.discard(row.id - offset)
         assert not _check_set
 


### PR DESCRIPTION
## Introduction

Previously in #104 , we introduce `orm_update_entries` API, which execute UPDATE query one time with exactly one set of `set_cols_value` and `where_cols_value`. This PR introduces the "executemany" verison of `orm_update_entries` API, which allow executing one UPDATE query with an iterable of sets of `set_cols_value` and `where_cols_value`.

Other changes:
1. table_spec: add `table_serialize_mappings` for conveniently serializing an iterable of mappings.

In my test with a 2000 rows table, using `orm_update_entries_many` is nearly 300 times faster than use a for loop with `orm_update_entries` to update each row in the table. 