### PR TITLE
feat: introduce `ColsSelectFactory` for enabling type check and completion suggestions over column names selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ class MyTable(TableSpec):
 ### (Recommended) Define typing helpers for your table
 
 It is recommended to define two typing helpers for your table:
+
 1. A `TypedDict` for generating col/value mapping with type check.
 2. A `ColsSelector` for generating a tuple for columns name selection with type check.
 
@@ -206,7 +207,7 @@ orm.orm_update_entries(
 )
 ```
 
-Also, there is an `executemany` version of ORM update API, `orm_update_entries_many`, which you can use many sets of params for the same UPDATE query execution. 
+Also, there is an `executemany` version of ORM update API, `orm_update_entries_many`, which you can use many sets of params for the same UPDATE query execution.
 Using this API is **SIGNIFICANTLY** faster with lower memory usage than calling `orm_update_entries` each time in a for loop.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ class MyTable(TableSpec):
 It is recommended to define two typing helpers for your table:
 
 1. A `TypedDict` for generating col/value mapping with type check.
-2. A `ColsSelector` for generating a tuple for columns name selection with type check.
+2. A `ColsSelector` for generating a tuple for columns name selection with type check and completion suggestions.
 
 `simple_sqlite3_orm` APIs take mappings as params, and take tuples for columns selections.
-You can utilize the defined typing helpers to enable static type check over column names when using APIs, preventing column name typos or unsynced updates to column names.
+You can utilize the defined typing helpers to enable static type chec with completion suggestions over column names when using APIs, preventing column name typos or unsynced updates to column names.
 
 ```python
 from typing import TypedDict

--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -31,7 +31,11 @@ from simple_sqlite3_orm._typing import (
     ConnectionFactoryType,
     RowFactoryType,
 )
-from simple_sqlite3_orm._utils import ConstrainRepr, TypeAffinityRepr
+from simple_sqlite3_orm._utils import (
+    ColsCheckerFactory,
+    ConstrainRepr,
+    TypeAffinityRepr,
+)
 
 try:
     from simple_sqlite3_orm._version import __version__, __version_tuple__, version
@@ -67,4 +71,5 @@ __all__ = [
     # typing helper
     "CreateIndexParams",
     "CreateTableParams",
+    "ColsCheckerFactory",
 ]

--- a/src/simple_sqlite3_orm/__init__.py
+++ b/src/simple_sqlite3_orm/__init__.py
@@ -32,7 +32,7 @@ from simple_sqlite3_orm._typing import (
     RowFactoryType,
 )
 from simple_sqlite3_orm._utils import (
-    ColsCheckerFactory,
+    ColsSelectFactory,
     ConstrainRepr,
     TypeAffinityRepr,
 )
@@ -71,5 +71,5 @@ __all__ = [
     # typing helper
     "CreateIndexParams",
     "CreateTableParams",
-    "ColsCheckerFactory",
+    "ColsSelectFactory",
 ]

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -21,6 +21,7 @@ from simple_sqlite3_orm._sqlite_spec import (
     SQLiteTypeAffinityLiteral,
 )
 
+T = TypeVar("T")
 P = ParamSpec("P")
 RT = TypeVar("RT")
 
@@ -201,3 +202,25 @@ def gen_sql_stmt(*components: str, end_with: str | None = ";") -> str:
         if end_with:
             buffer.write(end_with)
         return buffer.getvalue().strip()
+
+
+class ColsCheckerFactory(tuple[T, ...]):
+    """A factory type to generate cols name checker.
+
+    Usage:
+
+    ```python
+    MyTableCols = Literal["entry_id", "entry_context", "entry_type"]
+    MyTableColsChecker = ColsCheckerFactory[MyTableCols]
+
+    # now you can use `MyTableColsChecker` to specify a tuple of cols name as follow:
+    cols_to_select = MyTableColsChecker("unknown", "invalid_col")  # type checker err
+    cols_to_select = MyTableColsChecker("entry_id", "entry_type")  # valid
+
+    # at runtime, `cols_to_select` is a regular `tuple` object.
+    ```
+
+    """
+
+    def __new__(cls, *cols: T) -> tuple[T, ...]:
+        return tuple(cols)

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -204,7 +204,7 @@ def gen_sql_stmt(*components: str, end_with: str | None = ";") -> str:
         return buffer.getvalue().strip()
 
 
-class ColsCheckerFactory(tuple[T, ...]):
+class ColsSelectFactory(tuple[T, ...]):
     """A factory type to generate cols name checker.
 
     Usage:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,19 @@ import sqlite3
 import string
 import time
 from pathlib import Path
-from typing import Callable, Generator, Optional, TypedDict, get_args
+from typing import Callable, Generator, Literal, Optional, TypedDict, get_args
 
 import pytest
 from pydantic import PlainSerializer, PlainValidator
 from typing_extensions import Annotated
 
-from simple_sqlite3_orm import ConstrainRepr, TableSpec, TypeAffinityRepr, utils
+from simple_sqlite3_orm import (
+    ColsSelectFactory,
+    ConstrainRepr,
+    TableSpec,
+    TypeAffinityRepr,
+    utils,
+)
 from tests.sample_db.table import (
     Choice123,
     ChoiceABC,
@@ -57,6 +63,10 @@ class SimpleTableForTestCols(TypedDict, total=False):
     extra: Optional[float]
     int_str: int
 
+
+SimpleTableForTestColsSelect = ColsSelectFactory[
+    Literal["id", "id_str", "extra", "int_str"]
+]
 
 # sqlite3 lib features set
 

--- a/tests/test__orm.py
+++ b/tests/test__orm.py
@@ -20,6 +20,7 @@ from tests.conftest import (
     SELECT_ALL_BATCH_SIZE,
     SimpleTableForTest,
     SimpleTableForTestCols,
+    SimpleTableForTestColsSelect,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ class TestORMBase:
     def test_create_index(self, orm_inst: SimpleTableORM):
         orm_inst.orm_create_index(
             index_name="id_str_index",
-            index_keys=("id_str",),
+            index_keys=SimpleTableForTestColsSelect("id_str"),
             allow_existed=True,
             unique=True,
         )
@@ -71,7 +72,7 @@ class TestORMBase:
         with pytest.raises(sqlite3.DatabaseError):
             orm_inst.orm_create_index(
                 index_name="id_str_index",
-                index_keys=("id_str",),
+                index_keys=SimpleTableForTestColsSelect("id_str"),
                 allow_existed=False,
             )
 
@@ -90,7 +91,7 @@ class TestORMBase:
                 # NOTE: no row_factory specified, int_str here is not deserialized
                 None,
                 (1, str(ENTRY_FOR_TEST.int_str)),
-                ("id",),
+                SimpleTableForTestColsSelect("id"),
                 SimpleTableForTestCols(id=ENTRY_FOR_TEST.id),
             ),
             (
@@ -102,7 +103,7 @@ class TestORMBase:
             (
                 SimpleTableForTest.table_deserialize_astuple_row_factory,
                 (1, ENTRY_FOR_TEST.int_str),
-                ("id",),
+                SimpleTableForTestColsSelect("id"),
                 SimpleTableForTestCols(id=ENTRY_FOR_TEST.id),
             ),
         ),
@@ -336,8 +337,8 @@ class TestORMUpdateEntriesMany:
 
     def test_with_where_cols(self, _setup_orm: SimpleTableORM):
         _setup_orm.orm_update_entries_many(
-            set_cols=("int_str",),
-            where_cols=("id",),
+            set_cols=SimpleTableForTestColsSelect("int_str"),
+            where_cols=SimpleTableForTestColsSelect("id"),
             set_cols_value=(
                 SimpleTableForTestCols(int_str=i)
                 for i in range(TEST_ORM_UPDAT_ENTRIES_MANY_ENTRIES_COUNT)
@@ -353,7 +354,7 @@ class TestORMUpdateEntriesMany:
         self, _setup_orm: SimpleTableORM
     ):
         _setup_orm.orm_update_entries_many(
-            set_cols=("int_str",),
+            set_cols=SimpleTableForTestColsSelect("int_str"),
             where_stmt="WHERE id = :check_id",
             set_cols_value=(
                 SimpleTableForTestCols(int_str=i)
@@ -372,7 +373,7 @@ class TestORMUpdateEntriesMany:
 
         _setup_orm.orm_update_entries_many(
             or_option="replace",
-            set_cols=("int_str",),
+            set_cols=SimpleTableForTestColsSelect("int_str"),
             where_stmt="WHERE id = :check_id",
             set_cols_value=repeat(
                 SimpleTableForTestCols(int_str=update_value), times=repeat_times
@@ -399,7 +400,7 @@ class TestORMUpdateEntriesMany:
             _extra_params_iter=_preapre_params(),
             _stmt=_setup_orm.orm_table_spec.table_update_stmt(
                 update_target=_setup_orm.orm_table_name,
-                set_cols=("int_str", "id"),
+                set_cols=SimpleTableForTestColsSelect("int_str", "id"),
                 where_stmt="WHERE id = :check_id",
             ),
         )
@@ -445,13 +446,13 @@ def test_create_table(opts):
             [
                 CreateIndexParams(
                     index_name="test_index",
-                    index_cols=("id_str",),
+                    index_cols=SimpleTableForTestColsSelect("id_str"),
                     if_not_exists=True,
                     unique=True,
                 ),
                 CreateIndexParams(
                     index_name="test_index2",
-                    index_cols=("int_str",),
+                    index_cols=SimpleTableForTestColsSelect("int_str"),
                 ),
             ],
         ),

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     SQLITE3_COMPILE_OPTION_FLAGS,
     SimpleTableForTest,
     SimpleTableForTestCols,
+    SimpleTableForTestColsSelect,
 )
 
 TBL_NAME = "test_table"
@@ -121,7 +122,9 @@ class TestTableSpecWithDB:
     def test_lookup_entry(self, db_conn: sqlite3.Connection, prepare_test_entry):
         _to_lookup = self.ENTRY_FOR_TEST
         table_select_stmt = SimpleTableForTest.table_select_stmt(
-            select_from=TBL_NAME, select_cols="rowid, *", where_cols=("id",)
+            select_from=TBL_NAME,
+            select_cols="rowid, *",
+            where_cols=SimpleTableForTestColsSelect("id"),
         )
         with db_conn as _conn:
             _cur = _conn.execute(table_select_stmt, {"id": _to_lookup.id})
@@ -276,7 +279,7 @@ class TestTableSpecWithDB:
         _stmt = SimpleTableForTest.table_select_stmt(
             select_from=TBL_NAME,
             select_cols="int_str AS str_int, int_str, count(*) AS count",
-            where_cols=("id",),
+            where_cols=SimpleTableForTestColsSelect("id"),
         )
         with db_conn as conn:
             _cur = conn.execute(_stmt, SimpleTableForTestCols(id=ENTRY_FOR_TEST.id))
@@ -296,7 +299,7 @@ class TestTableSpecWithDB:
         _stmt = SimpleTableForTest.table_select_stmt(
             select_from=TBL_NAME,
             select_cols="count(*) AS total_entry_num, int_str AS str_int, int_str",
-            where_cols=("id",),
+            where_cols=SimpleTableForTestColsSelect("id"),
         )
         with db_conn as conn:
             _cur = conn.execute(_stmt, SimpleTableForTestCols(id=ENTRY_FOR_TEST.id))


### PR DESCRIPTION
## Introduction

This PR introduces a new helper type `ColsSelectFactory` for developer to define columns checker. This will enable static type chec with completion suggestions over column names when using ORM APIs, preventing column name typos or unsynced updates to column names.

README.md is updated accordingly to advise the use of `ColsSelectFactory`.