### PR TITLE
fix: fix python 3.8 compatibility, fix test CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,16 +92,14 @@ jobs:
       - name: Checkout commit
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python_version }}
-          cache: "pip"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Setup test environment
+      - name: Install python from apt source
         run: |
-          python -m pip install -q -U pip
-          pip install -U uv
+          sudo apt update
+          sudo apt install -y --no-install-recommends python
 
       - name: Execute pytest
-        run: uv run pytest
+        # NOTE: use the system default python
+        run: uv run --no-managed-python pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,18 +40,13 @@ jobs:
           # sonarcloud needs main branch's ref
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      # also see https://docs.astral.sh/uv/guides/integration/github/#multiple-python-versions
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
 
-      - name: Install package
-        run: |
-          python -m pip install -q -U pip
-          pip install -U uv
-
-      - name: Execute pytest with coverage
+      - name: Execute pytest via coverage by uv
         run: |
           uv run coverage run -m pytest --junit-xml=test_result/junit.xml
           uv run coverage xml -o test_result/coverage.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python_version }}
+          enable-cache: true
 
       - name: Execute pytest via coverage by uv
         run: |
@@ -94,6 +95,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Install python from apt source
         run: |
@@ -102,4 +105,4 @@ jobs:
 
       - name: Execute pytest
         # NOTE: use the system default python
-        run: uv run --no-managed-python pytest
+        run: uv run --python ${{ matrix.python_version }} --no-managed-python pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Install python from apt source
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends python
+          sudo apt install -y --no-install-recommends python-is-python3
 
       - name: Execute pytest
         # NOTE: use the system default python

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import sys
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, ClassVar, Generator, Iterable, Literal, TypedDict, TypeVar
@@ -39,11 +40,19 @@ class CreateIndexParams(TypedDict):
 class TableSpec(BaseModel):
     """Define table as pydantic model, with specific APIs."""
 
-    table_columns: ClassVar[MappingProxyType[str, FieldInfo]]
-    """A view of TableSpec's model_fields."""
+    if sys.version_info >= (3, 9):
+        table_columns: ClassVar[MappingProxyType[str, FieldInfo]]
+        """A view of TableSpec's model_fields."""
 
-    table_columns_by_index: ClassVar[tuple[str, ...]]
-    """Ordered tuple of column names, matching exactly with table schema."""
+        table_columns_by_index: ClassVar[tuple[str, ...]]
+        """Ordered tuple of column names, matching exactly with table schema."""
+
+    else:
+        table_columns: ClassVar[MappingProxyType]
+        """A view of TableSpec's model_fields."""
+
+        table_columns_by_index: ClassVar[tuple]
+        """Ordered tuple of column names, matching exactly with table schema."""
 
     @classmethod
     def __pydantic_init_subclass__(cls, **_) -> None:

--- a/src/simple_sqlite3_orm/_table_spec.py
+++ b/src/simple_sqlite3_orm/_table_spec.py
@@ -40,14 +40,14 @@ class CreateIndexParams(TypedDict):
 class TableSpec(BaseModel):
     """Define table as pydantic model, with specific APIs."""
 
-    if sys.version_info >= (3, 9):
+    if sys.version_info >= (3, 9):  # pragma: no cover
         table_columns: ClassVar[MappingProxyType[str, FieldInfo]]
         """A view of TableSpec's model_fields."""
 
         table_columns_by_index: ClassVar[tuple[str, ...]]
         """Ordered tuple of column names, matching exactly with table schema."""
 
-    else:
+    else:  # pragma: no cover
         table_columns: ClassVar[MappingProxyType]
         """A view of TableSpec's model_fields."""
 

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -204,7 +204,7 @@ def gen_sql_stmt(*components: str, end_with: str | None = ";") -> str:
         return buffer.getvalue().strip()
 
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 9):  # pragma: no cover
 
     class ColsSelectFactory(tuple[T, ...]):
         """A factory type to generate cols name checker.
@@ -229,7 +229,7 @@ if sys.version_info >= (3, 9):
         def __new__(cls, *cols: T) -> tuple[T, ...]:
             return tuple(cols)
 
-else:
+else:  # pragma: no cover
     from typing import Tuple
 
     class ColsSelectFactory(Tuple[T, ...]):

--- a/src/simple_sqlite3_orm/_utils.py
+++ b/src/simple_sqlite3_orm/_utils.py
@@ -204,23 +204,53 @@ def gen_sql_stmt(*components: str, end_with: str | None = ";") -> str:
         return buffer.getvalue().strip()
 
 
-class ColsSelectFactory(tuple[T, ...]):
-    """A factory type to generate cols name checker.
+if sys.version_info >= (3, 9):
 
-    Usage:
+    class ColsSelectFactory(tuple[T, ...]):
+        """A factory type to generate cols name checker.
 
-    ```python
-    MyTableCols = Literal["entry_id", "entry_context", "entry_type"]
-    MyTableColsChecker = ColsCheckerFactory[MyTableCols]
+        Usage:
 
-    # now you can use `MyTableColsChecker` to specify a tuple of cols name as follow:
-    cols_to_select = MyTableColsChecker("unknown", "invalid_col")  # type checker err
-    cols_to_select = MyTableColsChecker("entry_id", "entry_type")  # valid
+        ```python
+        MyTableCols = Literal["entry_id", "entry_context", "entry_type"]
+        MyTableColsChecker = ColsCheckerFactory[MyTableCols]
 
-    # at runtime, `cols_to_select` is a regular `tuple` object.
-    ```
+        # now you can use `MyTableColsChecker` to specify a tuple of cols name as follow:
+        cols_to_select = MyTableColsChecker(
+            "unknown", "invalid_col"
+        )  # type checker err
+        cols_to_select = MyTableColsChecker("entry_id", "entry_type")  # valid
 
-    """
+        # at runtime, `cols_to_select` is a regular `tuple` object.
+        ```
 
-    def __new__(cls, *cols: T) -> tuple[T, ...]:
-        return tuple(cols)
+        """
+
+        def __new__(cls, *cols: T) -> tuple[T, ...]:
+            return tuple(cols)
+
+else:
+    from typing import Tuple
+
+    class ColsSelectFactory(Tuple[T, ...]):
+        """A factory type to generate cols name checker.
+
+        Usage:
+
+        ```python
+        MyTableCols = Literal["entry_id", "entry_context", "entry_type"]
+        MyTableColsChecker = ColsCheckerFactory[MyTableCols]
+
+        # now you can use `MyTableColsChecker` to specify a tuple of cols name as follow:
+        cols_to_select = MyTableColsChecker(
+            "unknown", "invalid_col"
+        )  # type checker err
+        cols_to_select = MyTableColsChecker("entry_id", "entry_type")  # valid
+
+        # at runtime, `cols_to_select` is a regular `tuple` object.
+        ```
+
+        """
+
+        def __new__(cls, *cols: T) -> tuple[T, ...]:
+            return tuple(cols)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -4,8 +4,8 @@ from typing import Optional
 
 import pytest
 
-from simple_sqlite3_orm import ConstrainRepr, TypeAffinityRepr
 from simple_sqlite3_orm._sqlite_spec import SQLiteTypeAffinity
+from simple_sqlite3_orm._utils import ConstrainRepr, TypeAffinityRepr
 from tests.sample_db._types import Choice123, ChoiceABC, SomeIntLiteral, SomeStrLiteral
 
 


### PR DESCRIPTION
Due to mis-use of uv in test CI, since v0.12.0rc0, actually all tests are executed under python3.12. This causes some python 3.8 compatible issues not being found. 

This PR fixes the found py3.8 compat issue, and fixes the test CI to properly test on each supported python version.

Changes:
1. _utils.py: fix py3.8 compat issue.
2. _table_spec.py: fix py3.8 compat issue.
3. test CI: fix multi python version test, now tests are executed under target python version properly.
4. test CI: fix multi ubuntu version test, now tests are using the corresponding ubuntu's python to run the tests.