### PR TITLE
ci: integrate docker based tests for supported ubuntu version tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,4 +91,3 @@ jobs:
         working-directory: ./tests/container
         run: |
           docker compose -f ./docker-compose.yml run --rm tester-${{ matrix.ubuntu_base }}
-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   pytest_on_supported_os_version:
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: true
       matrix:
@@ -86,6 +89,13 @@ jobs:
     steps:
       - name: Checkout commit
         uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run test under test base container
         working-directory: ./tests/container

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,32 +77,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os:
-          # - ubuntu-20.04
+        ubuntu_base:
+          - ubuntu-18.04
+          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
-        include:
-          # - os: ubuntu-20.04
-          #   python_version: "3.8"
-          - os: ubuntu-22.04
-            python_version: "3.10"
-          - os: ubuntu-24.04
-            python_version: "3.12"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout commit
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install python from apt source
+      - name: Run test under test base container
+        working-directory: ./tests/container
         run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends python-is-python3
+          docker compose -f ./docker-compose.yml run --rm tester-${{ matrix.ubuntu_base }}
 
-      - name: Execute pytest
-        # NOTE: use the system default python
-        run: uv run --python ${{ matrix.python_version }} --no-managed-python pytest

--- a/tests/container/Dockerfile
+++ b/tests/container/Dockerfile
@@ -13,6 +13,8 @@ RUN set -eux; \
     PYTHON_PACKAGE="python3 python3-distutils"; \
     if [ "${UBUNTU_BASE}" = "ubuntu:18.04" ]; then \
         PYTHON_PACKAGE="python3.8 python3-distutils"; \
+    elif [ "${UBUNTU_BASE}" = "ubuntu:24.04" ]; then \
+        PYTHON_PACKAGE="python3"; \
     fi; \
     apt-get install -y -qq --no-install-recommends \
         curl \

--- a/tests/container/entrypoint.sh
+++ b/tests/container/entrypoint.sh
@@ -19,5 +19,5 @@ ln -s ${SRC}/LICENSE ${TEST_ROOT}
 
 cd ${TEST_ROOT}
 uv run --python python3 --no-managed-python coverage run -m pytest --junit-xml=${OUTPUT_DIR}/pytest.xml ${@:-}
-uv run --python python3 --no-managed-python coverage combine
+uv run --python python3 --no-managed-python coverage combine || true
 uv run --python python3 --no-managed-python coverage xml -o ${OUTPUT_DIR}/coverage.xml

--- a/tests/test__table_spec.py
+++ b/tests/test__table_spec.py
@@ -24,13 +24,24 @@ ENTRY_FOR_TEST = SimpleTableForTest(id=123, id_str="123", extra=0.123, int_str=9
     "table_create_params",
     (
         (CreateTableParams(if_not_exists=True)),
-        (CreateTableParams(strict=True)),
+        pytest.param(
+            CreateTableParams(strict=True),
+            marks=pytest.mark.skipif(
+                not SQLITE3_FEATURE_FLAGS.STRICT_AVAILABLE,
+                reason="STRICT table option is not available for this sqlite3 lib version",
+            ),
+        ),
         (CreateTableParams(temporary=True)),
         (CreateTableParams(without_rowid=True)),
-        (
+        (CreateTableParams(if_not_exists=True, temporary=True, without_rowid=True)),
+        pytest.param(
             CreateTableParams(
                 if_not_exists=True, strict=True, temporary=True, without_rowid=True
-            )
+            ),
+            marks=pytest.mark.skipif(
+                not SQLITE3_FEATURE_FLAGS.STRICT_AVAILABLE,
+                reason="STRICT table option is not available for this sqlite3 lib version",
+            ),
         ),
     ),
 )

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -175,7 +175,7 @@ class TestWithSampleDBWithAsyncIO:
         self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
     ):
         logger.info("test remove and confirm the removed entries")
-        if SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
+        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
             logger.warning(
                 (
                     "Current runtime sqlite3 lib version doesn't support RETURNING statement:"

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -180,6 +180,25 @@ class TestWithSampleDBWithAsyncIO:
     ):
         logger.info("test remove and confirm the removed entries")
         for entry in entries_to_remove:
+            _res = await async_pool.orm_delete_entries(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+            )
+            assert _res == 1
+
+    @pytest.mark.skipif(
+        not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
+        f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
+        "The test of RETURNING statement will be skipped here.",
+    )
+    async def test_delete_entries_with_returning(
+        self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
+    ):
+        logger.info("test remove and confirm the removed entries")
+        for entry in entries_to_remove:
             _res = await async_pool.orm_delete_entries_with_returning(
                 SampleTableCols(
                     key_id=entry.key_id,
@@ -194,25 +213,6 @@ class TestWithSampleDBWithAsyncIO:
 
             assert len(_deleted_entry_list) == 1
             assert _deleted_entry_list[0] == entry
-
-    @pytest.mark.skipif(
-        not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
-        reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
-        f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
-        "The test of RETURNING statement will be skipped here.",
-    )
-    async def test_delete_entries_with_returning(
-        self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
-    ):
-        logger.info("test remove and confirm the removed entries")
-        for entry in entries_to_remove:
-            _res = await async_pool.orm_delete_entries(
-                SampleTableCols(
-                    key_id=entry.key_id,
-                    prim_key_sha256hash=entry.prim_key_sha256hash,
-                ),
-            )
-            assert _res == 1
 
     async def test_check_timer(
         self, start_timer: tuple[asyncio.Task[None], asyncio.Event]

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -171,7 +171,10 @@ class TestWithSampleDBWithAsyncIO:
             async for _ in await _wrapped_mocked_select_entries():
                 ...
 
-    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="test delete with returning when possible",
+    )
     async def test_delete_entries(
         self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
     ):
@@ -193,7 +196,7 @@ class TestWithSampleDBWithAsyncIO:
             assert _deleted_entry_list[0] == entry
 
     @pytest.mark.skipif(
-        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
         reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
         f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
         "The test of RETURNING statement will be skipped here.",

--- a/tests/test_e2e/test_async_orm.py
+++ b/tests/test_e2e/test_async_orm.py
@@ -171,45 +171,45 @@ class TestWithSampleDBWithAsyncIO:
             async for _ in await _wrapped_mocked_select_entries():
                 ...
 
+    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
     async def test_delete_entries(
         self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
     ):
         logger.info("test remove and confirm the removed entries")
-        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
-            logger.warning(
-                (
-                    "Current runtime sqlite3 lib version doesn't support RETURNING statement:"
-                    f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
-                    "The test of RETURNING statement will be skipped here."
-                )
+        for entry in entries_to_remove:
+            _res = await async_pool.orm_delete_entries_with_returning(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+                _returning_cols="*",
             )
 
-            for entry in entries_to_remove:
-                _res = await async_pool.orm_delete_entries(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    # _limit=1,
-                )
-                assert _res == 1
-        else:
-            for entry in entries_to_remove:
-                _res = await async_pool.orm_delete_entries_with_returning(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    _returning_cols="*",
-                    # _limit=1,
-                )
+            _deleted_entry_list = []
+            async for _item in _res:
+                _deleted_entry_list.append(_item)
 
-                _deleted_entry_list = []
-                async for _item in _res:
-                    _deleted_entry_list.append(_item)
+            assert len(_deleted_entry_list) == 1
+            assert _deleted_entry_list[0] == entry
 
-                assert len(_deleted_entry_list) == 1
-                assert _deleted_entry_list[0] == entry
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
+        f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
+        "The test of RETURNING statement will be skipped here.",
+    )
+    async def test_delete_entries_with_returning(
+        self, async_pool: SampleDBAsyncio, entries_to_remove: list[SampleTable]
+    ):
+        logger.info("test remove and confirm the removed entries")
+        for entry in entries_to_remove:
+            _res = await async_pool.orm_delete_entries(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+            )
+            assert _res == 1
 
     async def test_check_timer(
         self, start_timer: tuple[asyncio.Task[None], asyncio.Event]

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -112,7 +112,7 @@ class TestWithSampleDB:
         entries_to_remove: list[SampleTable],
     ):
         logger.info("test remove and confirm the removed entries")
-        if SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
+        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
             logger.warning(
                 (
                     "Current runtime sqlite3 lib version doesn't support RETURNING statement:"

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -106,7 +106,10 @@ class TestWithSampleDB:
         assert len(_looked_up) == len(setup_test_data)
         assert all(_entry in _looked_up for _entry in setup_test_data.values())
 
-    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="test delete with returning when possible",
+    )
     def test_delete_entries(
         self,
         setup_test_data: dict[str, SampleTable],
@@ -126,7 +129,7 @@ class TestWithSampleDB:
             assert _res == 1
 
     @pytest.mark.skipif(
-        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
         reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
         f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
         "The test of RETURNING statement will be skipped here.",

--- a/tests/test_e2e/test_orm.py
+++ b/tests/test_e2e/test_orm.py
@@ -106,47 +106,51 @@ class TestWithSampleDB:
         assert len(_looked_up) == len(setup_test_data)
         assert all(_entry in _looked_up for _entry in setup_test_data.values())
 
+    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
     def test_delete_entries(
         self,
         setup_test_data: dict[str, SampleTable],
         entries_to_remove: list[SampleTable],
     ):
         logger.info("test remove and confirm the removed entries")
-        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
-            logger.warning(
-                (
-                    "Current runtime sqlite3 lib version doesn't support RETURNING statement:"
-                    f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
-                    "The test of RETURNING statement will be skipped here."
-                )
+        for entry in entries_to_remove:
+            _res = self.orm_inst.orm_delete_entries(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+                # NOTE(20241230): limit on update/delete requires compile flag SQLITE_ENABLE_UPDATE_DELETE_LIMIT enabled,
+                #   which is not set to be enabled by default. See https://www.sqlite.org/compile.html for more details.
+                # _limit=1,
             )
+            assert _res == 1
 
-            for entry in entries_to_remove:
-                _res = self.orm_inst.orm_delete_entries(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    # NOTE(20241230): limit on update/delete requires compile flag SQLITE_ENABLE_UPDATE_DELETE_LIMIT enabled,
-                    #   which is not set to be enabled by default. See https://www.sqlite.org/compile.html for more details.
-                    # _limit=1,
-                )
-                assert _res == 1
-        else:
-            for entry in entries_to_remove:
-                _res = self.orm_inst.orm_delete_entries_with_returning(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    _returning_cols="*",
-                    # _limit=1,
-                )
-                assert isinstance(_res, Generator)
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
+        f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
+        "The test of RETURNING statement will be skipped here.",
+    )
+    def test_delete_entries_with_returning(
+        self,
+        setup_test_data: dict[str, SampleTable],
+        entries_to_remove: list[SampleTable],
+    ):
+        logger.info("test remove and confirm the removed entries")
+        for entry in entries_to_remove:
+            _res = self.orm_inst.orm_delete_entries_with_returning(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+                _returning_cols="*",
+                # _limit=1,
+            )
+            assert isinstance(_res, Generator)
 
-                _res = list(_res)
-                assert len(_res) == 1
-                assert _res[0] == entry
+            _res = list(_res)
+            assert len(_res) == 1
+            assert _res[0] == entry
 
         logger.info("confirm the remove")
         sql_stmt = self.orm_inst.orm_table_spec.table_select_stmt(

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -154,7 +154,10 @@ class TestWithSampleDBAndThreadPool:
             for _ in _wrapped_mocked_select_entries():
                 ...
 
-    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="test delete with returning when possible",
+    )
     def test_delete_entries(
         self, thread_pool: SampleDBConnectionPool, entries_to_remove: list[SampleTable]
     ):
@@ -170,7 +173,7 @@ class TestWithSampleDBAndThreadPool:
             assert _res == 1
 
     @pytest.mark.skipif(
-        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
         reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
         f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
         "The test of RETURNING statement will be skipped here.",

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -154,42 +154,44 @@ class TestWithSampleDBAndThreadPool:
             for _ in _wrapped_mocked_select_entries():
                 ...
 
+    @pytest.mark.skipif(not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE)
     def test_delete_entries(
         self, thread_pool: SampleDBConnectionPool, entries_to_remove: list[SampleTable]
     ):
         logger.info("test remove and confirm the removed entries")
-        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
-            logger.warning(
-                (
-                    "Current runtime sqlite3 lib version doesn't support RETURNING statement:"
-                    f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
-                    "The test of RETURNING statement will be skipped here."
-                )
+        for entry in entries_to_remove:
+            _res = thread_pool.orm_delete_entries(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+                # _limit=1,
             )
+            assert _res == 1
 
-            for entry in entries_to_remove:
-                _res = thread_pool.orm_delete_entries(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    # _limit=1,
-                )
-                assert _res == 1
-        else:
-            for entry in entries_to_remove:
-                _res = thread_pool.orm_delete_entries_with_returning(
-                    SampleTableCols(
-                        key_id=entry.key_id,
-                        prim_key_sha256hash=entry.prim_key_sha256hash,
-                    ),
-                    _returning_cols="*",
-                    # _limit=1,
-                )
-                _res_list = list(_res)
+    @pytest.mark.skipif(
+        SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE,
+        reason="Current runtime sqlite3 lib version doesn't support RETURNING statement:"
+        f"{sqlite3.sqlite_version_info=}, needs 3.35 and above. "
+        "The test of RETURNING statement will be skipped here.",
+    )
+    def test_delete_entries_with_returning(
+        self, thread_pool: SampleDBConnectionPool, entries_to_remove: list[SampleTable]
+    ):
+        logger.info("test remove and confirm the removed entries")
+        for entry in entries_to_remove:
+            _res = thread_pool.orm_delete_entries_with_returning(
+                SampleTableCols(
+                    key_id=entry.key_id,
+                    prim_key_sha256hash=entry.prim_key_sha256hash,
+                ),
+                _returning_cols="*",
+                # _limit=1,
+            )
+            _res_list = list(_res)
 
-                assert len(_res_list) == 1
-                assert _res_list[0] == entry
+            assert len(_res_list) == 1
+            assert _res_list[0] == entry
 
 
 _THREADS = 6

--- a/tests/test_e2e/test_threadpool_orm.py
+++ b/tests/test_e2e/test_threadpool_orm.py
@@ -158,7 +158,7 @@ class TestWithSampleDBAndThreadPool:
         self, thread_pool: SampleDBConnectionPool, entries_to_remove: list[SampleTable]
     ):
         logger.info("test remove and confirm the removed entries")
-        if SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
+        if not SQLITE3_FEATURE_FLAGS.RETURNING_AVAILABLE:
             logger.warning(
                 (
                     "Current runtime sqlite3 lib version doesn't support RETURNING statement:"


### PR DESCRIPTION
## Introduction

This PR integrates the docker based tests to test CI for testing on supported ubuntu versions.

Other changes:
1. tests/container: minor fix to Dockerfile and entrypoint.sh.
2. tests: properly skip tests that requires higher sqlite3 lib version, like `STRICT` table option and delete with returning.
