### PR TITLE
chore: pyproject.toml: set fallback_version for hatch-vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dev = [
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "src/simple_sqlite3_orm/_version.py"
 


### PR DESCRIPTION
Provide a fallback_version for hatch-vcs, so that package build will not fail when git history is truncated(like dependabot with uv ecosystem).
Also see https://setuptools-scm.readthedocs.io/en/latest/config/ and https://github.com/ofek/hatch-vcs for more details.